### PR TITLE
WIP: 0.10.0

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,9 +28,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --ignore F821
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --ignore=C901 --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --ignore=C901,F821 --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,10 @@
 # 0.10.0
 - `ImageData.from_json()` can now be used on paths to json files
-- Added `COCO_LabelsDataConverter` for COCO annotations
+- Added `COCODataConverter` for COCO annotations
 - Added tests for `DataConverter`
 - Added `utils.imagesize` (taken from https://github.com/shibukawa/imagesize_py), with support of fsspec file-like objects
+- Added DetectionModel for YOLOv5 in `inference_models.detection.yolov5`
+- Pipeline's model logging level changed from INFO to DEBUG.
 
 # 0.9.0
 - Added `preprocess_input` and `input_size` for Object Detection API detectors;

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,16 @@
 - Added `utils.imagesize` (taken from https://github.com/shibukawa/imagesize_py), with support of fsspec file-like objects
 - Added DetectionModel for YOLOv5 in `inference_models.detection.yolov5`
 - Pipeline's model logging level changed from INFO to DEBUG.
+- Add `FiftyOneSession` for simplier using with FiftyOne (in `utils.fiftyone`)
+- Added function `utils.images_data.flatten_additional_bboxes_data_in_image_data`
+- `DetectionInferencer`, `ClassificationInferencer` and `PipelineInferencer` now can accept list of `ImageData` (of `BboxData` for `ClassificationInferencer`), with `batch_size_default=16` for Detection/Pipeline and `batch_size_default=32` for Classification
+- Add method `.load_detection_inferencer()` to class `DetectionModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.DetectionInferencer`
+- Add method `.load_classification_inferencer()` to class `ClassificationModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.ClassificationInferencer`
+- Add method `.load_pipeline_inferencer()` to class `PipelineModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.PipelineInferencer`
+- Argument `classification_model_spec` is now `None` by default for `PipelineModelSpec`
+
+- Add argument `return_as_pil_image: bool` set default as `False` in `visualize_image_data`, `visualize_images_data_side_by_side` and `visualize_image_data_matching_side_by_side`, that returns images as `PIL.Image.Image`
+
 
 # 0.9.0
 - Added `preprocess_input` and `input_size` for Object Detection API detectors;

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 0.10.0
+- `ImageData.from_json()` can now be used on paths to json files
+- Added `COCO_LabelsDataConverter` for COCO annotations
+- Added tests for `DataConverter`
+- Added `utils.imagesize` (taken from https://github.com/shibukawa/imagesize_py), with support of fsspec file-like objects
+
 # 0.9.0
 - Added `preprocess_input` and `input_size` for Object Detection API detectors;
 - Fix exception bug in `non_max_suppression_image_data_using_tf` when `image_data.bboxes_data` are empty

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -1,10 +1,10 @@
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 from cv_pipeliner.core.data import ImageData, BboxData
 from cv_pipeliner.batch_generators.image_data import BatchGeneratorImageData
 from cv_pipeliner.batch_generators.bbox_data import BatchGeneratorBboxData
 from cv_pipeliner.visualizers.core.image_data import visualize_image_data, visualize_images_data_side_by_side
-from cv_pipeliner.metrics.image_data_matching import ImageDataMatching
+from cv_pipeliner.metrics.image_data_matching import ImageDataMatching, BboxDataMatching
 from cv_pipeliner.visualizers.core.image_data_matching import visualize_image_data_matching_side_by_side
 from cv_pipeliner.metrics.detection import get_df_detection_metrics, get_df_detection_recall_per_class
 from cv_pipeliner.metrics.classification import get_df_classification_metrics

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -13,7 +13,7 @@ from cv_pipeliner.utils.images_datas import (
     rotate_image_data, crop_image_data, get_perspective_matrix_for_base_keypoints,
     apply_perspective_transform_to_image_data,
     thumbnail_image_data, non_max_suppression_image_data, uncrop_bboxes_data,
-    resize_image_data
+    resize_image_data, split_image_by_grid, flatten_additional_bboxes_data_in_image_data
 )
 from cv_pipeliner.inference_models.detection.object_detection_api import (
     ObjectDetectionAPI_KFServing, ObjectDetectionAPI_ModelSpec, ObjectDetectionAPI_TFLite_ModelSpec,
@@ -28,9 +28,8 @@ from cv_pipeliner.inference_models.pipeline import PipelineModelSpec, PipelineMo
 from cv_pipeliner.inferencers.detection import DetectionInferencer
 from cv_pipeliner.inferencers.classification import ClassificationInferencer
 from cv_pipeliner.inferencers.pipeline import PipelineInferencer
-
-
 from cv_pipeliner.data_converters.coco import COCODataConverter
 from cv_pipeliner.data_converters.brickit import BrickitDataConverter
 from cv_pipeliner.data_converters.json import JSONDataConverter
 from cv_pipeliner.data_converters.supervisely import SuperviselyDataConverter
+from cv_pipeliner.utils.imagesize import get_image_size

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -20,6 +20,7 @@ from cv_pipeliner.inference_models.detection.object_detection_api import (
     ObjectDetectionAPI_pb_ModelSpec
 )
 from cv_pipeliner.inference_models.detection.pytorch import PytorchDetection_ModelSpec
+from cv_pipeliner.inference_models.detection.yolov5 import YOLOv5_ModelSpec
 from cv_pipeliner.inference_models.classification.tensorflow import (
     TensorFlow_ClassificationModelSpec, TensorFlow_ClassificationModelSpec_TFServing
 )
@@ -27,3 +28,9 @@ from cv_pipeliner.inference_models.pipeline import PipelineModelSpec, PipelineMo
 from cv_pipeliner.inferencers.detection import DetectionInferencer
 from cv_pipeliner.inferencers.classification import ClassificationInferencer
 from cv_pipeliner.inferencers.pipeline import PipelineInferencer
+
+
+from cv_pipeliner.data_converters.coco import COCODataConverter
+from cv_pipeliner.data_converters.brickit import BrickitDataConverter
+from cv_pipeliner.data_converters.json import JSONDataConverter
+from cv_pipeliner.data_converters.supervisely import SuperviselyDataConverter

--- a/cv_pipeliner/core/data.py
+++ b/cv_pipeliner/core/data.py
@@ -116,6 +116,11 @@ class BboxData:
     def coords(self) -> Tuple[int, int, int, int]:
         return (round(self.xmin), round(self.ymin), round(self.xmax), round(self.ymax))
 
+    @property
+    def coords_n(self) -> Tuple[int, int, int, int]:
+        width, height = self.get_image_size()
+        return self.xmin / width, self.ymin / height, self.xmax / width, self.ymax / height
+
     def coords_with_offset(
         self,
         xmin_offset: Union[int, float] = 0,
@@ -283,8 +288,9 @@ class BboxData:
         if d is None:
             return BboxData(image_path=image_path)
         if isinstance(d, str) or isinstance(d, Path):
-            d = json.load(fsspec.open(d, 'r'))
-        if isinstance(d, fsspec.core.OpenFile):
+            with fsspec.open(d, 'r') as f:
+                d = json.loads(f.read())
+        elif isinstance(d, fsspec.core.OpenFile):
             with d as f:
                 d = json.load(f)
 
@@ -369,8 +375,9 @@ class ImageData:
         if d is None:
             return ImageData(image_path=image_path)
         if isinstance(d, str) or isinstance(d, Path):
-            d = json.load(fsspec.open(d, 'r'))
-        if isinstance(d, fsspec.core.OpenFile):
+            with fsspec.open(d, 'r') as f:
+                d = json.loads(f.read())
+        elif isinstance(d, fsspec.core.OpenFile):
             with d as f:
                 d = json.load(f)
         if 'image_data' in d:

--- a/cv_pipeliner/core/data.py
+++ b/cv_pipeliner/core/data.py
@@ -323,7 +323,7 @@ class ImageData:
         inplace: bool = False
     ) -> Union[None, np.ndarray]:
         return open_image_for_object(obj=self, inplace=inplace)
-    
+
     def get_image_size(self) -> Tuple[int, int]:
         """
             Returns (width, height) of image without opening it fully.

--- a/cv_pipeliner/core/data_converter.py
+++ b/cv_pipeliner/core/data_converter.py
@@ -12,15 +12,8 @@ from cv_pipeliner.core.data import BboxData, ImageData
 
 
 class DataConverter(abc.ABC):
-    def __init__(
-        self,
-        class_names: List[str] = None,
-        class_mapper: Dict[str, str] = None,
-        skip_nonexists: bool = False
-    ):
-        self.class_names = class_names
-        self.class_mapper = class_mapper
-        self.skip_nonexists = skip_nonexists
+    def __init__(self):
+        pass
 
     def filter_image_data(
         self,
@@ -49,17 +42,6 @@ class DataConverter(abc.ABC):
                     f"incorrect bbox (xmin, ymin, xmax, ymax): {(xmin, ymin, xmax, ymax)} "
                     "(xmin >= xmax or ymin >= ymax or xmin < 0 or ymin < 0). Skipping."
                 )
-                continue
-
-            if self.class_mapper is not None:
-                if bbox_data.label in self.class_mapper:
-                    bbox_data.label = self.class_mapper[bbox_data.label]
-            if (
-                self.class_names is not None and
-                (
-                    bbox_data.label not in self.class_names and self.skip_nonexists
-                )
-            ):
                 continue
 
             new_bboxes_data.append(bbox_data)

--- a/cv_pipeliner/core/data_converter.py
+++ b/cv_pipeliner/core/data_converter.py
@@ -48,6 +48,7 @@ class DataConverter(abc.ABC):
 
         image_data = ImageData(
             image_path=image_data.image_path,
+            image=image_data.image,
             bboxes_data=new_bboxes_data,
             additional_info=image_data.additional_info
         )

--- a/cv_pipeliner/data_converters/brickit.py
+++ b/cv_pipeliner/data_converters/brickit.py
@@ -11,16 +11,6 @@ from cv_pipeliner.core.data import BboxData, ImageData
 
 
 class BrickitDataConverter(DataConverter):
-    def __init__(self,
-                 class_names: List[str] = None,
-                 class_mapper: Dict[str, str] = None,
-                 skip_nonexists: bool = False):
-        super().__init__(
-            class_names=class_names,
-            class_mapper=class_mapper,
-            skip_nonexists=skip_nonexists
-        )
-
     def get_annot_from_image_data(
         self,
         image_data: ImageData
@@ -29,6 +19,7 @@ class BrickitDataConverter(DataConverter):
             'filename': image_data.image_name,
             'objects': []
         }
+        image_data = self.filter_image_data(image_data)
         for bbox_data in image_data.bboxes_data:
             bbox_data_json = bbox_data.json()
             obj = {
@@ -117,9 +108,13 @@ class BrickitDataConverter(DataConverter):
         if isinstance(annot, str) or isinstance(annot, Path):
             with fsspec.open(annot, 'r', encoding='utf8') as f:
                 annots = json.load(f)
-        if isinstance(annot, fsspec.core.OpenFile):
+        elif isinstance(annot, fsspec.core.OpenFile):
             with annot as f:
                 annots = json.load(f)
+        elif isinstance(annot, dict):
+            annots = [annot]
+        else:
+            annots = annot
         image_path = Pathy(image_path)
         annots = [annot for annot in annots if annot['filename'] == image_path.name]
 

--- a/cv_pipeliner/data_converters/brickit.py
+++ b/cv_pipeliner/data_converters/brickit.py
@@ -50,7 +50,7 @@ class BrickitDataConverter(DataConverter):
         if isinstance(annots, str) or isinstance(annots, Path):
             with fsspec.open(annots, 'r', encoding='utf8') as f:
                 annots = json.load(f)
-        if isinstance(annots, fsspec.core.OpenFile):
+        elif isinstance(annots, fsspec.core.OpenFile):
             with annots as f:
                 annots = json.load(f)
         images_dir = Pathy(images_dir)

--- a/cv_pipeliner/data_converters/coco.py
+++ b/cv_pipeliner/data_converters/coco.py
@@ -9,7 +9,7 @@ from cv_pipeliner.core.data import ImageData, BboxData
 from cv_pipeliner.utils.imagesize import get_image_size
 
 
-class COCO_LabelsDataConverter(DataConverter):
+class COCODataConverter(DataConverter):
     def __init__(self, class_names: List[str]):
         super().__init__()
         assert len(set(class_names)) == len(class_names), "There are duplicates in 'class_names'. Remove them."

--- a/cv_pipeliner/data_converters/coco.py
+++ b/cv_pipeliner/data_converters/coco.py
@@ -1,0 +1,77 @@
+from turtle import width
+from typing import Union, Dict, List
+from pathlib import Path
+
+import fsspec
+
+from cv_pipeliner.core.data_converter import DataConverter
+from cv_pipeliner.core.data import ImageData, BboxData
+from cv_pipeliner.utils.imagesize import get_image_size
+
+
+class COCO_LabelsDataConverter(DataConverter):
+    def __init__(self, class_names: List[str]):
+        super().__init__()
+        assert len(set(class_names)) == len(class_names), "There are duplicates in 'class_names'. Remove them."
+        self.class_names = class_names
+        self.class_name_to_idx = {
+            class_name: idx
+            for idx, class_name in enumerate(self.class_names)
+        }
+        self.idx_to_class_name = {
+            idx: class_name
+            for idx, class_name in enumerate(self.class_names)
+        }
+
+    def get_annot_from_image_data(
+        self,
+        image_data: ImageData
+    ) -> List[str]:
+        image_data = self.filter_image_data(image_data)
+        width, height = image_data.get_image_size()
+        txt_results = []
+        for bbox_data in image_data.bboxes_data:
+            w = bbox_data.xmax - bbox_data.xmin
+            h = bbox_data.ymax - bbox_data.ymin
+            xcenter = bbox_data.xmin + w / 2
+            ycenter = bbox_data.ymin + h / 2
+            xcenter, w = round(xcenter / width, 6), round(w / width, 6)
+            ycenter, h = round(ycenter / height, 6), round(h / height, 6)
+            idx = self.class_name_to_idx[bbox_data.label]
+            txt_results.append(f"{idx} {xcenter} {ycenter} {w} {h}")
+        return txt_results
+
+    @DataConverter.assert_image_data
+    def get_image_data_from_annot(
+        self,
+        image_path: Union[str, Path],
+        annot: Union[Path, str, Dict, fsspec.core.OpenFile, List[str]]
+    ) -> ImageData:
+        if isinstance(annot, str) or isinstance(annot, Path):
+            with fsspec.open(annot, 'r', encoding='utf8') as f:
+                annots = f.read()
+        elif isinstance(annot, fsspec.core.OpenFile):
+            with annot as f:
+                annots = f.read()
+        elif isinstance(annot, List):
+            annots = '\n'.join(annot)
+
+        width, height = get_image_size(image_path)
+        bboxes_data = []
+        for line in annots.strip().split('\n'):
+            idx, xcenter, ycenter, w, h = line.split(' ')
+            label = self.idx_to_class_name[int(idx)]
+            xcenter, ycenter, w, h = float(xcenter), float(ycenter), float(w), float(h)
+            xcenter, w = xcenter * width, w * width
+            ycenter, h = ycenter * height, h * height
+            bboxes_data.append(
+                BboxData(
+                    xmin=xcenter-w/2,
+                    ymin=ycenter-h/2,
+                    xmax=xcenter+w/2,
+                    ymax=ycenter+h/2,
+                    label=label
+                )
+            )
+
+        return ImageData(image_path=image_path, bboxes_data=bboxes_data)

--- a/cv_pipeliner/data_converters/json.py
+++ b/cv_pipeliner/data_converters/json.py
@@ -1,6 +1,6 @@
 import json
 
-from typing import Union, Dict, List
+from typing import Union, Dict
 from pathlib import Path
 from pathy import Pathy
 
@@ -11,20 +11,14 @@ from cv_pipeliner.core.data import ImageData
 
 
 class JSONDataConverter(DataConverter):
-    def __init__(self,
-                 class_names: List[str] = None,
-                 class_mapper: Dict[str, str] = None,
-                 skip_nonexists: bool = False):
-        super().__init__(
-            class_names=class_names,
-            class_mapper=class_mapper,
-            skip_nonexists=skip_nonexists
-        )
+    def __init__(self):
+        pass
 
     def get_annot_from_image_data(
         self,
         image_data: ImageData
     ) -> Dict:
+        image_data = self.filter_image_data(image_data)
         return image_data.json()
 
     @DataConverter.assert_image_data
@@ -36,8 +30,10 @@ class JSONDataConverter(DataConverter):
         if isinstance(annot, str) or isinstance(annot, Path):
             with fsspec.open(annot, 'r', encoding='utf8') as f:
                 annots = json.load(f)
-        if isinstance(annot, fsspec.core.OpenFile):
+        elif isinstance(annot, fsspec.core.OpenFile):
             with annot as f:
                 annots = json.load(f)
+        else:
+            annots = annot
         image_path = Pathy(image_path)
         return ImageData.from_json(annots, image_path=image_path)

--- a/cv_pipeliner/data_converters/supervisely.py
+++ b/cv_pipeliner/data_converters/supervisely.py
@@ -10,16 +10,6 @@ from cv_pipeliner.core.data import BboxData, ImageData
 
 
 class SuperviselyDataConverter(DataConverter):
-    def __init__(self,
-                 class_names: List[str] = None,
-                 class_mapper: Dict[str, str] = None,
-                 skip_nonexists: bool = False):
-        super().__init__(
-            class_names=class_names,
-            class_mapper=class_mapper,
-            skip_nonexists=skip_nonexists
-        )
-
     @DataConverter.assert_image_data
     def get_image_data_from_annot(
         self,
@@ -57,6 +47,7 @@ class SuperviselyDataConverter(DataConverter):
         self,
         image_data: ImageData
     ) -> Dict:
+        image_data = self.filter_image_data(image_data)
         image = image_data.open_image()
         height, width, _ = image.shape
         annot = {

--- a/cv_pipeliner/inference_models/classification/core.py
+++ b/cv_pipeliner/inference_models/classification/core.py
@@ -20,6 +20,10 @@ class ClassificationModelSpec(ModelSpec):
     def inference_model_cls(self) -> Type['ClassificationModel']:
         pass
 
+    def load_detection_inferencer(self) -> 'ClassificationInferencer':
+        from cv_pipeliner.inferencers.classification import ClassificationInferencer
+        return ClassificationInferencer(self.load())
+
 
 class ClassificationModel(InferenceModel):
     def __init__(self, model_spec: ClassificationModelSpec):

--- a/cv_pipeliner/inference_models/detection/core.py
+++ b/cv_pipeliner/inference_models/detection/core.py
@@ -31,6 +31,10 @@ class DetectionModelSpec(ModelSpec):
     def inference_model_cls(self) -> Type['DetectionModel']:
         pass
 
+    def load_detection_inferencer(self) -> 'DetectionInferencer':
+        from cv_pipeliner.inferencers.detection import DetectionInferencer
+        return DetectionInferencer(self.load())
+
 
 class DetectionModel(InferenceModel):
     @abc.abstractmethod

--- a/cv_pipeliner/inference_models/detection/yolov5.py
+++ b/cv_pipeliner/inference_models/detection/yolov5.py
@@ -16,7 +16,9 @@ from cv_pipeliner.utils.images import denormalize_bboxes
 
 @dataclass
 class YOLOv5_ModelSpec(DetectionModelSpec):
-    # Can be loaded as torch.hub.load('ultralytics/yolov5', 'yolov5s')
+    """
+    note: model_path can be set as torch.hub.load('ultralytics/yolov5', 'yolov5s')
+    """
     model_path: Union[None, str, Path, 'torch.nn.Module']  # noqa: F821
 
     class_names: Union[None, List[str]]

--- a/cv_pipeliner/inference_models/detection/yolov5.py
+++ b/cv_pipeliner/inference_models/detection/yolov5.py
@@ -1,0 +1,181 @@
+import json
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple, Union, Type, Callable
+from pathlib import Path
+
+import numpy as np
+import fsspec
+
+from cv_pipeliner.core.inference_model import get_preprocess_input_from_script_file
+from cv_pipeliner.inference_models.detection.core import (
+    DetectionModelSpec, DetectionModel, DetectionInput, DetectionOutput
+)
+from cv_pipeliner.utils.images import denormalize_bboxes
+
+
+@dataclass
+class YOLOv5_ModelSpec(DetectionModelSpec):
+    model_path: Union[None, str, Path, 'torch.nn.Module']  # Can be loaded as torch.hub.load('ultralytics/yolov5', 'yolov5s')
+    class_names: Union[None, List[str]]
+    preprocess_input: Union[Callable[[List[np.ndarray]], np.ndarray], str, Path, None] = None
+    input_size: Union[Tuple[int, int], List[int]] = (None, None)
+
+    @property
+    def inference_model_cls(self) -> Type['YOLOv5_DetectionModel']:
+        from cv_pipeliner.inference_models.detection.yolov5 import YOLOv5_DetectionModel
+        return YOLOv5_DetectionModel
+
+
+class YOLOv5_DetectionModel(DetectionModel):
+    def _load_yolov5_model(self, model_spec: YOLOv5_ModelSpec):
+        import torch
+
+        if isinstance(model_spec.model_path, torch.nn.Module):
+            self.model = model_spec.model_path
+            return
+
+        temp_file = tempfile.NamedTemporaryFile(suffix='.pt')
+        with fsspec.open(model_spec.model_path, 'rb') as src:
+            temp_file.write(src.read())
+        model_path_tmp = Path(temp_file.name)
+        self.model = torch.hub.load('ultralytics/yolov5', 'custom', path=str(model_path_tmp))
+        temp_file.close()
+
+    def __init__(
+        self,
+        model_spec: YOLOv5_ModelSpec
+    ):
+        super().__init__(model_spec)
+
+        if model_spec.class_names is not None:
+            if isinstance(model_spec.class_names, str) or isinstance(model_spec.class_names, Path):
+                with fsspec.open(model_spec.class_names, 'r', encoding='utf-8') as out:
+                    self.class_names = np.array(json.load(out))
+            else:
+                self.class_names = np.array(model_spec.class_names)
+        else:
+            self.class_names = None
+
+        self._load_yolov5_model(model_spec)
+        if isinstance(model_spec.preprocess_input, str) or isinstance(model_spec.preprocess_input, Path):
+            self._preprocess_input = get_preprocess_input_from_script_file(
+                script_file=model_spec.preprocess_input
+            )
+        else:
+            if model_spec.preprocess_input is None:
+                self._preprocess_input = lambda x: x
+            else:
+                self._preprocess_input = model_spec.preprocess_input
+
+    def _raw_predict_images(
+        self,
+        input: DetectionInput,
+        score_threshold: float,
+        size: int
+    ) -> Tuple[List[np.ndarray], List[np.ndarray], List[np.ndarray], List[np.ndarray]]:
+        self.model.conf = score_threshold
+        results = self.model(input, size=size)
+        results_pd = results.pandas()
+
+        n_raw_bboxes, n_raw_keypoints, n_raw_scores, n_raw_classes = [], [], [], []
+        for result_pd in results_pd.xyxyn:
+            n_raw_bboxes.append(np.array(result_pd[['xmin', 'ymin', 'xmax', 'ymax']]))
+            n_raw_keypoints.append(np.array([]).reshape(len(result_pd), 0, 2))
+            n_raw_scores.append(np.array(result_pd["confidence"]))
+            n_raw_classes.append(np.array(result_pd["class"]))
+        return n_raw_bboxes, n_raw_keypoints, n_raw_scores, n_raw_classes
+
+    def _postprocess_prediction(
+        self,
+        raw_bboxes: np.ndarray,
+        raw_keypoints: np.ndarray,
+        raw_scores: np.ndarray,
+        raw_classes: np.ndarray,
+        score_threshold: float,
+        width: int,
+        height: int,
+        classification_top_n: int
+    ) -> Tuple[
+        List[Tuple[int, int, int, int]],
+        List[List[Tuple[int, int]]],
+        List[float], List[List[str]], List[List[float]]
+    ]:
+
+        raw_bboxes = denormalize_bboxes(raw_bboxes, width, height)
+        mask = raw_scores > score_threshold
+        bboxes = raw_bboxes[mask]
+        keypoints = raw_keypoints[mask]
+        scores = raw_scores[mask]
+        classes = raw_classes[mask]
+
+        correct_non_repeated_bboxes_idxs = []
+        bboxes_set = set()
+        for idx, bbox in enumerate(bboxes):
+            xmin, ymin, xmax, ymax = bbox
+            if xmax - xmin > 0 and ymax - ymin > 0 and (xmin, ymin, xmax, ymax) not in bboxes_set:
+                bboxes_set.add((xmin, ymin, xmax, ymax))
+                correct_non_repeated_bboxes_idxs.append(idx)
+
+        bboxes = bboxes[correct_non_repeated_bboxes_idxs]
+        keypoints = keypoints[correct_non_repeated_bboxes_idxs]
+        scores = scores[correct_non_repeated_bboxes_idxs]
+        classes = classes[correct_non_repeated_bboxes_idxs]
+        classes_scores = scores.copy()
+        if self.class_names is not None:
+            class_names_top_n = np.array([
+                [class_name for i in range(classification_top_n)]
+                for class_name in self.class_names[classes.astype(np.int32)]
+            ])
+            classes_scores_top_n = np.array([
+                [score for _ in range(classification_top_n)]
+                for score in classes_scores
+            ])
+        else:
+            class_names_top_n = np.array([
+                [None for _ in range(classification_top_n)]
+                for _ in classes
+            ])
+            classes_scores_top_n = np.array([
+                [score for _ in range(classification_top_n)]
+                for score in classes_scores
+            ])
+
+        return bboxes, keypoints, scores, class_names_top_n, classes_scores_top_n
+
+    def predict(
+        self,
+        input: DetectionInput,
+        score_threshold: float,
+        classification_top_n: int = 1,
+        size: int = 640  # Custom resize image
+    ) -> DetectionOutput:
+        input = self.preprocess_input(input)
+        n_raw_bboxes, n_raw_keypoints, n_raw_scores, n_raw_classes = self._raw_predict_images(input, score_threshold, size)
+        results = [
+            self._postprocess_prediction(
+                raw_bboxes=raw_bboxes,
+                raw_keypoints=raw_keypoints,
+                raw_scores=raw_scores,
+                raw_classes=raw_classes,
+                score_threshold=score_threshold,
+                width=image.shape[1],
+                height=image.shape[0],
+                classification_top_n=classification_top_n
+            )
+            for image, raw_bboxes, raw_keypoints, raw_scores, raw_classes in zip(
+                input, n_raw_bboxes, n_raw_keypoints, n_raw_scores, n_raw_classes
+            )
+        ]
+        n_pred_bboxes, n_pred_keypoints, n_pred_scores, n_pred_class_names_top_k, n_pred_scores_top_k = [
+            [res[i] for res in results]
+            for i in range(5)
+        ]
+        return n_pred_bboxes, n_pred_keypoints, n_pred_scores, n_pred_class_names_top_k, n_pred_scores_top_k
+
+    def preprocess_input(self, input: DetectionInput):
+        return self._preprocess_input(input)
+
+    @property
+    def input_size(self) -> Tuple[int, int]:
+        return (None, None)

--- a/cv_pipeliner/inference_models/detection/yolov5.py
+++ b/cv_pipeliner/inference_models/detection/yolov5.py
@@ -16,7 +16,9 @@ from cv_pipeliner.utils.images import denormalize_bboxes
 
 @dataclass
 class YOLOv5_ModelSpec(DetectionModelSpec):
-    model_path: Union[None, str, Path, 'torch.nn.Module']  # Can be loaded as torch.hub.load('ultralytics/yolov5', 'yolov5s')
+    # Can be loaded as torch.hub.load('ultralytics/yolov5', 'yolov5s')
+    model_path: Union[None, str, Path, 'torch.nn.Module']  # noqa: F821
+
     class_names: Union[None, List[str]]
     preprocess_input: Union[Callable[[List[np.ndarray]], np.ndarray], str, Path, None] = None
     input_size: Union[Tuple[int, int], List[int]] = (None, None)

--- a/cv_pipeliner/inference_models/pipeline.py
+++ b/cv_pipeliner/inference_models/pipeline.py
@@ -15,12 +15,16 @@ from cv_pipeliner.logging import logger
 @dataclass
 class PipelineModelSpec(ModelSpec):
     detection_model_spec: DetectionModelSpec
-    classification_model_spec: Union[ClassificationModelSpec, None]
+    classification_model_spec: Union[ClassificationModelSpec, None] = None
 
     @property
     def inference_model_cls(self) -> Type['PipelineModel']:
         from cv_pipeliner.inference_models.pipeline import PipelineModel
         return PipelineModel
+
+    def load_pipeline_inferencer(self) -> 'PipelineInferencer':
+        from cv_pipeliner.inferencers.pipeline import PipelineInferencer
+        return PipelineInferencer(self.load())
 
 
 Bbox = Tuple[int, int, int, int]  # (ymin, xmin, ymax, xmax)

--- a/cv_pipeliner/inference_models/pipeline.py
+++ b/cv_pipeliner/inference_models/pipeline.py
@@ -90,7 +90,7 @@ class PipelineModel(InferenceModel):
         classification_kwargs: Dict[str, Any] = {},
         disable_tqdm_classification: bool = False
     ) -> PipelineOutput:
-        logger.info("Running detection...")
+        logger.debug("Running detection...")
         (
             n_pred_bboxes, n_pred_keypoints, n_pred_detection_scores,
             n_pred_class_names_top_k, n_pred_classification_scores_top_k
@@ -100,11 +100,11 @@ class PipelineModel(InferenceModel):
             classification_top_n=classification_top_n,
             **detection_kwargs
         )
-        logger.info(
+        logger.debug(
             f"Detection: found {np.sum([len(pred_bboxes) for pred_bboxes in n_pred_bboxes])} bboxes!"
         )
 
-        logger.info("Running classification...")
+        logger.debug("Running classification...")
         if self.classification_model is None:
             # Detector is the pipeline itself
             return (
@@ -132,7 +132,7 @@ class PipelineModel(InferenceModel):
                     pbar.update(len(pred_bboxes_batch))
         n_pred_labels_top_n = self._split_chunks(pred_labels_top_n, shapes)
         n_pred_classification_scores_top_n = self._split_chunks(pred_classification_scores_top_n, shapes)
-        logger.info("Classification end!")
+        logger.debug("Classification end!")
         return (
             n_pred_bboxes,
             n_pred_keypoints,

--- a/cv_pipeliner/inferencers/classification.py
+++ b/cv_pipeliner/inferencers/classification.py
@@ -142,8 +142,14 @@ class ClassificationInferencer(Inferencer):
         top_n: int = 1,
         open_images_in_data: bool = False,
         disable_tqdm: bool = False,
-        progress_callback: Callable[[int], None] = lambda progress: None
+        progress_callback: Callable[[int], None] = lambda progress: None,
+        batch_size_default: int = 32
     ) -> Union[List[ImageData], List[List[BboxData]]]:
+        if isinstance(data_gen, list):
+            if all(isinstance(d, ImageData) for d in data_gen):
+                data_gen = BatchGeneratorImageData(data_gen, batch_size=batch_size_default)
+            elif all(isinstance(d, BboxData) for d in data_gen):
+                data_gen = BatchGeneratorBboxData(data_gen, batch_size=batch_size_default)
         if isinstance(data_gen, BatchGeneratorImageData):
             return self._predict_images_data(
                 images_data_gen=data_gen,

--- a/cv_pipeliner/inferencers/detection.py
+++ b/cv_pipeliner/inferencers/detection.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union
 
 from tqdm import tqdm
 
@@ -54,13 +54,16 @@ class DetectionInferencer(Inferencer):
 
     def predict(
         self,
-        images_data_gen: BatchGeneratorImageData,
+        images_data_gen: Union[List[ImageData], BatchGeneratorImageData],
         score_threshold: float,
         open_images_in_images_data: bool = False,  # Warning: hard memory use
         open_cropped_images_in_bboxes_data: bool = False,
         disable_tqdm: bool = False,
-        progress_callback: Callable[[int], None] = lambda progress: None
+        progress_callback: Callable[[int], None] = lambda progress: None,
+        batch_size_default: int = 16
     ) -> List[ImageData]:
+        if isinstance(images_data_gen, list):
+            images_data_gen = BatchGeneratorImageData(images_data_gen, batch_size=batch_size_default)
         assert isinstance(images_data_gen, BatchGeneratorImageData)
         pred_images_data = []
         with tqdm(total=len(images_data_gen.data), disable=disable_tqdm) as pbar:

--- a/cv_pipeliner/inferencers/pipeline.py
+++ b/cv_pipeliner/inferencers/pipeline.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 from tqdm import tqdm
 
 from cv_pipeliner.core.data import BboxData, ImageData
@@ -68,7 +68,7 @@ class PipelineInferencer(Inferencer):
 
     def predict(
         self,
-        images_data_gen: BatchGeneratorImageData,
+        images_data_gen: Union[List[ImageData], BatchGeneratorImageData],
         detection_score_threshold: float,
         classification_top_n: int = 1,
         open_images_in_images_data: bool = False,  # Warning: hard memory use
@@ -78,8 +78,11 @@ class PipelineInferencer(Inferencer):
         classification_batch_size: int = 16,
         detection_kwargs: Dict[str, Any] = {},
         classification_kwargs: Dict[str, Any] = {},
-        progress_callback: Callable[[int], None] = lambda progress: None
+        progress_callback: Callable[[int], None] = lambda progress: None,
+        batch_size_default: int = 16
     ) -> List[ImageData]:
+        if isinstance(images_data_gen, list):
+            images_data_gen = BatchGeneratorImageData(images_data_gen, batch_size=batch_size_default)
         assert isinstance(images_data_gen, BatchGeneratorImageData)
         pred_images_data = []
         with tqdm(total=len(images_data_gen.data), disable=disable_tqdm) as pbar:

--- a/cv_pipeliner/utils/datapipe.py
+++ b/cv_pipeliner/utils/datapipe.py
@@ -1,6 +1,7 @@
 import json
 import numpy as np
 from typing import Any, Dict, IO
+
 from datapipe.store.filedir import ItemStoreFileAdapter
 from cv_pipeliner.core.data import ImageData
 

--- a/cv_pipeliner/utils/fiftyone.py
+++ b/cv_pipeliner/utils/fiftyone.py
@@ -1,0 +1,171 @@
+import copy
+import logging
+import os
+import sys
+
+from pathlib import Path
+from typing import Literal, Optional, Union, Dict, Tuple
+
+from cv_pipeliner.core.data import ImageData, BboxData
+from cv_pipeliner.metrics.image_data_matching import ImageDataMatching
+from cv_pipeliner.utils.images_datas import flatten_additional_bboxes_data_in_image_data
+
+logger = logging.getLogger('cv_pipeliner.utils.fiftyone')
+
+
+class FifyOneSession:
+    _counter = 0
+
+    def __init__(self, fiftyone_database_dir: Union[str, Path] = None):
+        assert FifyOneSession._counter == 0, (
+            "There is another instance of class FifyOneConverter. Delete it for using this class."
+        )
+        if 'fiftyone' in sys.modules:
+            logger.warning(
+                'Fiftyone is already imported to some base. The FifyOneConverter will reimport fiftyone and it can change the base.'
+            )
+            del sys.modules['fiftyone']
+        self.fiftyone_database_dir = fiftyone_database_dir
+        if self.fiftyone_database_dir is not None:
+            os.environ['FIFTYONE_DATABASE_DIR'] = str(self.fiftyone_database_dir)
+        import fiftyone
+        self.fiftyone = fiftyone
+
+        FifyOneSession._counter += 1
+
+    def __del__(self):
+        if self.fiftyone_database_dir is not None:
+            del os.environ['FIFTYONE_DATABASE_DIR']
+        del self.fiftyone
+        del sys.modules['fiftyone']
+        FifyOneSession._counter -= 1
+
+    def convert_bbox_data_to_fo_detection(self, bbox_data: BboxData) -> 'fiftyone.Detection':
+        xminn, yminn, xmaxn, ymaxn = bbox_data.coords_n
+        bounding_box = [xminn, yminn, xmaxn-xminn, ymaxn-yminn]
+        return self.fiftyone.Detection(label=bbox_data.label, bounding_box=bounding_box)
+
+    def convert_image_data_to_fo_detections(
+        self, image_data: ImageData,
+        include_additional_bboxes_data: bool = False
+    ) -> 'fiftyone.Detections':
+        if include_additional_bboxes_data:
+            image_data = flatten_additional_bboxes_data_in_image_data(image_data)
+
+        return self.fiftyone.Detections(
+            detections=list(map(self.convert_bbox_data_to_fo_detection, image_data.bboxes_data))
+        )
+
+    def convert_image_data_to_fo_detections_by_classes(
+        self,
+        image_data: ImageData,
+        include_additional_bboxes_data: bool = False
+    ) -> Dict[str, 'fiftyone.Detections']:
+        if include_additional_bboxes_data:
+            image_data = flatten_additional_bboxes_data_in_image_data(image_data)
+        class_names = sorted(set([bbox_data.label for bbox_data in image_data.bboxes_data]))
+        class_name_to_fo_detections = {
+            class_name: self.fiftyone.Detections(
+                detections=list(map(self.convert_bbox_data_to_fo_detection, [
+                    bbox_data for bbox_data in image_data.bboxes_data
+                    if bbox_data.label == class_name
+                ]))
+            )
+            for class_name in class_names
+        }
+        return class_name_to_fo_detections
+
+    def convert_image_data_matching_to_fo_detections(
+        self,
+        image_data_matching: ImageDataMatching,
+        model_type: Literal['detection', 'pipeline'],
+        label: Optional[str] = None
+    ) -> Tuple['fiftyone.Detections', 'fiftyone.Detections']:
+        """
+            Convert image_data_matching to FO.Detections, with labels written as "<label> [<error type>]".
+            Returns pair of true and pred detections: (true_detections, pred_detections)
+        """
+        assert model_type in ['detection', 'pipeline']
+        image_data_matching = copy.deepcopy(image_data_matching)
+
+        true_detections_instances = []
+        pred_detections_instances = []
+        for bbox_data_matching in image_data_matching.bboxes_data_matchings:
+            if model_type == 'detection':
+                bbox_error_type = bbox_data_matching.get_detection_error_type(label=label)
+            else:
+                bbox_error_type = bbox_data_matching.get_pipeline_error_type(label=label)
+            true_bbox_data = bbox_data_matching.true_bbox_data
+            pred_bbox_data = bbox_data_matching.pred_bbox_data
+            if true_bbox_data is not None:
+                true_bbox_data.label = f"{true_bbox_data.label} [{bbox_error_type}]"
+                true_detections_instances.append(self.convert_bbox_data_to_fo_detection(true_bbox_data))
+            if pred_bbox_data is not None:
+                pred_bbox_data.label = f"{pred_bbox_data.label} [{bbox_error_type}]"
+                pred_detections_instances.append(self.convert_bbox_data_to_fo_detection(pred_bbox_data))
+
+        true_detections = self.fiftyone.Detections(detections=true_detections_instances)
+        pred_detections = self.fiftyone.Detections(detections=pred_detections_instances)
+        return true_detections, pred_detections
+
+    def convert_image_data_matching_to_fo_detections_by_classes(
+        self,
+        image_data_matching: ImageDataMatching,
+        model_type: Literal['detection', 'pipeline'],
+        label: Optional[str] = None
+    ) -> Tuple[Dict[str, 'fiftyone.Detections'], Dict[str, 'fiftyone.Detections']]:
+        """
+            Convert image_data_matching to FO.Detections, where bboxes_data_matchings are matched by classes.
+
+            If argument 'label' is set, errors types counts as
+            binary classification of [0, 1], where 1 is 'label' and 0 is the other class. 
+
+            Returns part of dict [true_dict, pred_dict] of this format:
+            {
+                'class_type [error_type]': fiftyone.Detections
+            }
+        """
+        assert model_type in ['detection', 'pipeline']
+        errors_types = ['TP', 'FP', 'FN', 'TN', 'TP (extra bbox)', 'FP (extra bbox)']
+        class_names = sorted(set([
+            bbox_data_matching.true_bbox_data.label
+            for bbox_data_matching in image_data_matching.bboxes_data_matchings
+            if bbox_data_matching.true_bbox_data is not None
+        ] + [
+            bbox_data_matching.pred_bbox_data.label
+            for bbox_data_matching in image_data_matching.bboxes_data_matchings
+            if bbox_data_matching.pred_bbox_data is not None
+        ]))
+        class_name_to_fo_true_detections = {
+            f"{class_name} [{error_type}]": [] for class_name in class_names for error_type in errors_types
+        }
+        class_name_to_fo_pred_detections = {
+            f"{class_name} [{error_type}]": [] for class_name in class_names for error_type in errors_types
+        }
+        for bbox_data_matching in image_data_matching.bboxes_data_matchings:
+            if model_type == 'detection':
+                bbox_error_type = bbox_data_matching.get_detection_error_type(label=label)
+            else:
+                bbox_error_type = bbox_data_matching.get_pipeline_error_type(label=label)
+
+            true_bbox_data = bbox_data_matching.true_bbox_data
+            pred_bbox_data = bbox_data_matching.pred_bbox_data
+            if true_bbox_data is not None:
+                class_name_to_fo_true_detections[f"{true_bbox_data.label} [{bbox_error_type}]"].append(
+                    self.convert_bbox_data_to_fo_detection(true_bbox_data)
+                )
+            if pred_bbox_data is not None:
+                class_name_to_fo_pred_detections[f"{pred_bbox_data.label} [{bbox_error_type}]"].append(
+                    self.convert_bbox_data_to_fo_detection(pred_bbox_data)
+                )
+
+        for key in class_name_to_fo_true_detections:
+            class_name_to_fo_true_detections[key] = self.fiftyone.Detections(
+                detections=class_name_to_fo_true_detections[key]
+            )
+        for key in class_name_to_fo_pred_detections:
+            class_name_to_fo_pred_detections[key] = self.fiftyone.Detections(
+                detections=class_name_to_fo_pred_detections[key]
+            )
+
+        return class_name_to_fo_true_detections, class_name_to_fo_pred_detections

--- a/cv_pipeliner/utils/images_datas.py
+++ b/cv_pipeliner/utils/images_datas.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Literal, Tuple
+from typing import List, Literal, Optional, Tuple
 
 import numpy as np
 import cv2
@@ -801,4 +801,26 @@ def concat_images_data(
         }
     )
 
+    return image_data
+
+
+def flatten_additional_bboxes_data_in_image_data(
+    image_data: ImageData,
+    additional_bboxes_data_depth: Optional[int] = None,
+) -> ImageData:
+    image_data = copy.deepcopy(image_data)
+    bboxes_data = []
+
+    def _append_bbox_data(bbox_data: BboxData, depth: int):
+        if additional_bboxes_data_depth is not None and depth > additional_bboxes_data_depth:
+            return
+        bboxes_data.append(bbox_data)
+        for additional_bbox_data in bbox_data.additional_bboxes_data:
+            _append_bbox_data(additional_bbox_data)
+        bbox_data.additional_bboxes_data = []
+
+    for bbox_data in bboxes_data:
+        _append_bbox_data(bbox_data, depth=0)
+
+    image_data.bboxes_data = bboxes_data
     return image_data

--- a/cv_pipeliner/utils/imagesize.py
+++ b/cv_pipeliner/utils/imagesize.py
@@ -1,0 +1,367 @@
+import io
+import os
+import re
+import struct
+import fsspec
+from xml.etree import ElementTree
+
+_UNIT_KM = -3
+_UNIT_100M = -2
+_UNIT_10M = -1
+_UNIT_1M = 0
+_UNIT_10CM = 1
+_UNIT_CM = 2
+_UNIT_MM = 3
+_UNIT_0_1MM = 4
+_UNIT_0_01MM = 5
+_UNIT_UM = 6
+_UNIT_INCH = 6
+
+_TIFF_TYPE_SIZES = {
+  1: 1,
+  2: 1,
+  3: 2,
+  4: 4,
+  5: 8,
+  6: 1,
+  7: 1,
+  8: 2,
+  9: 4,
+  10: 8,
+  11: 4,
+  12: 8,
+}
+
+
+def _convertToDPI(density, unit):
+    if unit == _UNIT_KM:
+        return int(density * 0.0000254 + 0.5)
+    elif unit == _UNIT_100M:
+        return int(density * 0.000254 + 0.5)
+    elif unit == _UNIT_10M:
+        return int(density * 0.00254 + 0.5)
+    elif unit == _UNIT_1M:
+        return int(density * 0.0254 + 0.5)
+    elif unit == _UNIT_10CM:
+        return int(density * 0.254 + 0.5)
+    elif unit == _UNIT_CM:
+        return int(density * 2.54 + 0.5)
+    elif unit == _UNIT_MM:
+        return int(density * 25.4 + 0.5)
+    elif unit == _UNIT_0_1MM:
+        return density * 254
+    elif unit == _UNIT_0_01MM:
+        return density * 2540
+    elif unit == _UNIT_UM:
+        return density * 25400
+    return density
+
+
+def _convertToPx(value):
+    matched = re.match(r"(\d+(?:\.\d+)?)?([a-z]*)$", value)
+    if not matched:
+        raise ValueError("unknown length value: %s" % value)
+
+    length, unit = matched.groups()
+    if unit == "":
+        return float(length)
+    elif unit == "cm":
+        return float(length) * 96 / 2.54
+    elif unit == "mm":
+        return float(length) * 96 / 2.54 / 10
+    elif unit == "in":
+        return float(length) * 96
+    elif unit == "pc":
+        return float(length) * 96 / 6
+    elif unit == "pt":
+        return float(length) * 96 / 6
+    elif unit == "px":
+        return float(length)
+
+    raise ValueError("unknown unit type: %s" % unit)
+
+
+def get_image_size(filepath):
+    """
+    Return (width, height) for a given img file content
+    no requirements
+    :type filepath: Union[bytes, str, pathlib.Path]
+    :rtype Tuple[int, int]
+    """
+    height = -1
+    width = -1
+
+    if isinstance(filepath, io.BytesIO):  # file-like object
+        fhandle = filepath
+    elif isinstance(filepath, fsspec.core.OpenFile):  # file-like object
+        fhandle = filepath.__enter__()
+    else:
+        fhandle = fsspec.open(filepath, 'rb').__enter__()
+
+    try:
+        head = fhandle.read(24)
+        size = len(head)
+        # handle GIFs
+        if size >= 10 and head[:6] in (b'GIF87a', b'GIF89a'):
+            # Check to see if content_type is correct
+            try:
+                width, height = struct.unpack("<hh", head[6:10])
+            except struct.error:
+                raise ValueError("Invalid GIF file")
+        # see png edition spec bytes are below chunk length then and finally the
+        elif size >= 24 and head.startswith(b'\211PNG\r\n\032\n') and head[12:16] == b'IHDR':
+            try:
+                width, height = struct.unpack(">LL", head[16:24])
+            except struct.error:
+                raise ValueError("Invalid PNG file")
+        # Maybe this is for an older PNG version.
+        elif size >= 16 and head.startswith(b'\211PNG\r\n\032\n'):
+            # Check to see if we have the right content type
+            try:
+                width, height = struct.unpack(">LL", head[8:16])
+            except struct.error:
+                raise ValueError("Invalid PNG file")
+        # handle JPEGs
+        elif size >= 2 and head.startswith(b'\377\330'):
+            try:
+                fhandle.seek(0)  # Read 0xff next
+                size = 2
+                ftype = 0
+                while not 0xc0 <= ftype <= 0xcf or ftype in [0xc4, 0xc8, 0xcc]:
+                    fhandle.seek(size, 1)
+                    byte = fhandle.read(1)
+                    while ord(byte) == 0xff:
+                        byte = fhandle.read(1)
+                    ftype = ord(byte)
+                    size = struct.unpack('>H', fhandle.read(2))[0] - 2
+                # We are at a SOFn block
+                fhandle.seek(1, 1)  # Skip `precision' byte.
+                height, width = struct.unpack('>HH', fhandle.read(4))
+            except (struct.error, TypeError):
+                raise ValueError("Invalid JPEG file")
+        # handle JPEG2000s
+        elif size >= 12 and head.startswith(b'\x00\x00\x00\x0cjP  \r\n\x87\n'):
+            fhandle.seek(48)
+            try:
+                height, width = struct.unpack('>LL', fhandle.read(8))
+            except struct.error:
+                raise ValueError("Invalid JPEG2000 file")
+        # handle big endian TIFF
+        elif size >= 8 and head.startswith(b"\x4d\x4d\x00\x2a"):
+            offset = struct.unpack('>L', head[4:8])[0]
+            fhandle.seek(offset)
+            ifdsize = struct.unpack(">H", fhandle.read(2))[0]
+            for i in range(ifdsize):
+                tag, datatype, count, data = struct.unpack(">HHLL", fhandle.read(12))
+                if tag == 256:
+                    if datatype == 3:
+                        width = int(data / 65536)
+                    elif datatype == 4:
+                        width = data
+                    else:
+                        raise ValueError("Invalid TIFF file: width column data type should be SHORT/LONG.")
+                elif tag == 257:
+                    if datatype == 3:
+                        height = int(data / 65536)
+                    elif datatype == 4:
+                        height = data
+                    else:
+                        raise ValueError("Invalid TIFF file: height column data type should be SHORT/LONG.")
+                if width != -1 and height != -1:
+                    break
+            if width == -1 or height == -1:
+                raise ValueError("Invalid TIFF file: width and/or height IDS entries are missing.")
+        elif size >= 8 and head.startswith(b"\x49\x49\x2a\x00"):
+            offset = struct.unpack('<L', head[4:8])[0]
+            fhandle.seek(offset)
+            ifdsize = struct.unpack("<H", fhandle.read(2))[0]
+            for i in range(ifdsize):
+                tag, datatype, count, data = struct.unpack("<HHLL", fhandle.read(12))
+                if tag == 256:
+                    width = data
+                elif tag == 257:
+                    height = data
+                if width != -1 and height != -1:
+                    break
+            if width == -1 or height == -1:
+                raise ValueError("Invalid TIFF file: width and/or height IDS entries are missing.")
+        # handle little endian BigTiff
+        elif size >= 8 and head.startswith(b"\x49\x49\x2b\x00"):
+            bytesize_offset = struct.unpack('<L', head[4:8])[0]
+            if bytesize_offset != 8:
+                raise ValueError('Invalid BigTIFF file: Expected offset to be 8, found {} instead.'.format(offset))
+            offset = struct.unpack('<Q', head[8:16])[0]
+            fhandle.seek(offset)
+            ifdsize = struct.unpack("<Q", fhandle.read(8))[0]
+            for i in range(ifdsize):
+                tag, datatype, count, data = struct.unpack("<HHQQ", fhandle.read(20))
+                if tag == 256:
+                    width = data
+                elif tag == 257:
+                    height = data
+                if width != -1 and height != -1:
+                    break
+            if width == -1 or height == -1:
+                raise ValueError("Invalid BigTIFF file: width and/or height IDS entries are missing.")
+
+        # handle SVGs
+        elif size >= 5 and (head.startswith(b'<?xml') or head.startswith(b'<svg')):
+            fhandle.seek(0)
+            data = fhandle.read(1024)
+            try:
+                data = data.decode('utf-8')
+                width = re.search(r'[^-]width="(.*?)"', data).group(1)
+                height = re.search(r'[^-]height="(.*?)"', data).group(1)
+            except Exception:
+                raise ValueError("Invalid SVG file")
+            width = _convertToPx(width)
+            height = _convertToPx(height)
+
+        # handle Netpbm
+        elif head[:1] == b"P" and head[1:2] in b"123456":
+            fhandle.seek(2)
+            sizes = []
+
+            while True:
+                next_chr = fhandle.read(1)
+
+                if next_chr.isspace():
+                    continue
+
+                if next_chr == b"":
+                    raise ValueError("Invalid Netpbm file")
+
+                if next_chr == b"#":
+                    fhandle.readline()
+                    continue
+
+                if not next_chr.isdigit():
+                    raise ValueError("Invalid character found on Netpbm file")
+
+                size = next_chr
+                next_chr = fhandle.read(1)
+
+                while next_chr.isdigit():
+                    size += next_chr
+                    next_chr = fhandle.read(1)
+
+                sizes.append(int(size))
+
+                if len(sizes) == 2:
+                    break
+
+                fhandle.seek(-1, os.SEEK_CUR)
+            width, height = sizes
+
+    finally:
+        fhandle.close()
+
+    return width, height
+
+
+def getDPI(filepath):
+    """
+    Return (x DPI, y DPI) for a given img file content
+    no requirements
+    :type filepath: Union[bytes, str, pathlib.Path]
+    :rtype Tuple[int, int]
+    """
+    xDPI = -1
+    yDPI = -1
+
+    if not isinstance(filepath, bytes):
+        filepath = str(filepath)
+
+    with fsspec.open(filepath, 'rb') as fhandle:
+        head = fhandle.read(24)
+        size = len(head)
+        # handle GIFs
+        # GIFs doesn't have density
+        if size >= 10 and head[:6] in (b'GIF87a', b'GIF89a'):
+            pass
+        # see png edition spec bytes are below chunk length then and finally the
+        elif size >= 24 and head.startswith(b'\211PNG\r\n\032\n'):
+            chunkOffset = 8
+            chunk = head[8:]
+            while True:
+                chunkType = chunk[4:8]
+                if chunkType == b'pHYs':
+                    try:
+                        xDensity, yDensity, unit = struct.unpack(">LLB", chunk[8:])
+                    except struct.error:
+                        raise ValueError("Invalid PNG file")
+                    if unit:
+                        xDPI = _convertToDPI(xDensity, _UNIT_1M)
+                        yDPI = _convertToDPI(yDensity, _UNIT_1M)
+                    else:  # no unit
+                        xDPI = xDensity
+                        yDPI = yDensity
+                    break
+                elif chunkType == b'IDAT':
+                    break
+                else:
+                    try:
+                        dataSize, = struct.unpack(">L", chunk[0:4])
+                    except struct.error:
+                        raise ValueError("Invalid PNG file")
+                    chunkOffset += dataSize + 12
+                    fhandle.seek(chunkOffset)
+                    chunk = fhandle.read(17)
+        # handle JPEGs
+        elif size >= 2 and head.startswith(b'\377\330'):
+            try:
+                fhandle.seek(0)  # Read 0xff next
+                size = 2
+                ftype = 0
+                while not 0xc0 <= ftype <= 0xcf:
+                    if ftype == 0xe0:  # APP0 marker
+                        fhandle.seek(7, 1)
+                        unit, xDensity, yDensity = struct.unpack(">BHH", fhandle.read(5))
+                        if unit == 1 or unit == 0:
+                            xDPI = xDensity
+                            yDPI = yDensity
+                        elif unit == 2:
+                            xDPI = _convertToDPI(xDensity, _UNIT_CM)
+                            yDPI = _convertToDPI(yDensity, _UNIT_CM)
+                        break
+                    fhandle.seek(size, 1)
+                    byte = fhandle.read(1)
+                    while ord(byte) == 0xff:
+                        byte = fhandle.read(1)
+                    ftype = ord(byte)
+                    size = struct.unpack('>H', fhandle.read(2))[0] - 2
+            except struct.error:
+                raise ValueError("Invalid JPEG file")
+        # handle JPEG2000s
+        elif size >= 12 and head.startswith(b'\x00\x00\x00\x0cjP  \r\n\x87\n'):
+            fhandle.seek(32)
+            # skip JP2 image header box
+            headerSize = struct.unpack('>L', fhandle.read(4))[0] - 8
+            fhandle.seek(4, 1)
+            foundResBox = False
+            try:
+                while headerSize > 0:
+                    boxHeader = fhandle.read(8)
+                    boxType = boxHeader[4:]
+                    if boxType == b'res ':  # find resolution super box
+                        foundResBox = True
+                        headerSize -= 8
+                        break
+                    boxSize, = struct.unpack('>L', boxHeader[:4])
+                    fhandle.seek(boxSize - 8, 1)
+                    headerSize -= boxSize
+                if foundResBox:
+                    while headerSize > 0:
+                        boxHeader = fhandle.read(8)
+                        boxType = boxHeader[4:]
+                        if boxType == b'resd':  # Display resolution box
+                            yDensity, xDensity, yUnit, xUnit = struct.unpack(">HHBB", fhandle.read(10))
+                            xDPI = _convertToDPI(xDensity, xUnit)
+                            yDPI = _convertToDPI(yDensity, yUnit)
+                            break
+                        boxSize, = struct.unpack('>L', boxHeader[:4])
+                        fhandle.seek(boxSize - 8, 1)
+                        headerSize -= boxSize
+            except struct.error as e:
+                raise ValueError("Invalid JPEG2000 file")
+    return xDPI, yDPI

--- a/cv_pipeliner/visualizers/core/image_data.py
+++ b/cv_pipeliner/visualizers/core/image_data.py
@@ -1,6 +1,6 @@
 import collections
 import copy
-from typing import Literal, List, Tuple, Callable, Optional
+from typing import Literal, List, Tuple, Callable, Optional, Union
 
 import numpy as np
 import imutils
@@ -301,8 +301,9 @@ def visualize_image_data(
     include_additional_bboxes_data: bool = False,
     additional_bboxes_data_depth: Optional[int] = None,
     fontsize: int = 24,
-    thickness: int = 4
-) -> np.ndarray:
+    thickness: int = 4,
+    return_as_pil_image: bool = False
+) -> Union[np.ndarray, Image.Image]:
     image_data = get_image_data_filtered_by_labels(
         image_data=image_data,
         filter_by_labels=filter_by_labels
@@ -375,6 +376,9 @@ def visualize_image_data(
                 inplace=True
             )
 
+    if return_as_pil_image:
+        return Image.fromarray(image)
+
     return image
 
 
@@ -393,8 +397,9 @@ def visualize_images_data_side_by_side(
     include_additional_bboxes_data: bool = False,
     additional_bboxes_data_depth: Optional[int] = None,
     fontsize: int = 24,
-    thickness: int = 4
-) -> np.ndarray:
+    thickness: int = 4,
+    return_as_pil_image: bool = False
+) -> Union[np.ndarray, Image.Image]:
 
     if overlay:
         image_data1 = copy.deepcopy(image_data1)
@@ -432,5 +437,8 @@ def visualize_images_data_side_by_side(
         image = cv2.addWeighted(src1=true_ann_image, alpha=1., src2=pred_ann_image, beta=1., gamma=0.)
     else:
         image = cv2.hconcat([true_ann_image, pred_ann_image])
+
+    if return_as_pil_image:
+        return Image.fromarray(image)
 
     return image

--- a/cv_pipeliner/visualizers/core/image_data_matching.py
+++ b/cv_pipeliner/visualizers/core/image_data_matching.py
@@ -1,6 +1,7 @@
-from typing import List, Literal, Callable
+from typing import List, Literal, Callable, Union
 
 import numpy as np
+from PIL import Image
 
 from cv_pipeliner.core.data import BboxData, ImageData
 from cv_pipeliner.metrics.image_data_matching import ImageDataMatching
@@ -81,8 +82,9 @@ def visualize_image_data_matching_side_by_side(
     pred_filter_by_error_types: List[error_type] = ['TP', 'FP', 'FN', 'TP (extra bbox)', 'FP (extra bbox)'],
     draw_base_labels_with_given_label_to_base_label_image: Callable[[str], np.ndarray] = None,
     known_labels: List[str] = [],
-    label: str = None
-) -> np.ndarray:
+    label: str = None,
+    return_as_pil_image: bool = False
+) -> Union[np.ndarray, Image.Image]:
 
     (true_image_data_with_visualized_labels,
      pred_image_data_with_visualized_labels) = get_true_and_pred_images_data_with_visualized_labels(
@@ -102,7 +104,7 @@ def visualize_image_data_matching_side_by_side(
         if any(f"[{matching_error_type}]" in label for matching_error_type in pred_filter_by_error_types)
     ]
 
-    image = visualize_images_data_side_by_side(
+    return visualize_images_data_side_by_side(
         image_data1=true_image_data_with_visualized_labels,
         image_data2=pred_image_data_with_visualized_labels,
         use_labels1=true_use_labels, use_labels2=pred_use_labels,
@@ -111,5 +113,5 @@ def visualize_image_data_matching_side_by_side(
         filter_by_labels2=pred_filter_by_labels,
         known_labels=known_labels,
         draw_base_labels_with_given_label_to_base_label_image=draw_base_labels_with_given_label_to_base_label_image,
+        return_as_pil_image=return_as_pil_image
     )
-    return image

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import tempfile
+from pathlib import Path
+import pytest
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        yield d
+
+
+def assert_images_datas_equal(image_data1, image_data2):
+    bboxes_data1 = sorted(image_data1.bboxes_data, key=lambda x: x.coords)
+    bboxes_data2 = sorted(image_data2.bboxes_data, key=lambda x: x.coords)
+    for bbox_data1, bbox_data2 in zip(bboxes_data1, bboxes_data2):
+        assert bbox_data1.coords == bbox_data2.coords
+        assert bbox_data1.label == bbox_data2.label

--- a/tests/test_data/coco/000000000009.jpg
+++ b/tests/test_data/coco/000000000009.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35cdfe8259aca40d564baf33ee749d82ce852446bd9574f0c47551d8bfffda99
+size 224297

--- a/tests/test_data/coco/000000000025.jpg
+++ b/tests/test_data/coco/000000000025.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8f12a26d8803701cabac80494b080f998e5ed9bafaf61a2825ce6212c85487a
+size 196370

--- a/tests/test_data/coco/000000000030.jpg
+++ b/tests/test_data/coco/000000000030.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0444b10826d376ad9075805061405f6071a62b80eda29c5f284ed77b093d5b1d
+size 71463

--- a/tests/test_data/coco/000000000034.jpg
+++ b/tests/test_data/coco/000000000034.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c46871034fa901ae795a8bb916ba7f2f728507cab9e511cced0986bd083d193
+size 406018

--- a/tests/test_data/coco/000000000036.jpg
+++ b/tests/test_data/coco/000000000036.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b04d9d0a1ea8b930e11f293a832bdfe8d43892fdb96f1038219196d41a86b95
+size 260207

--- a/tests/test_data_converters.py
+++ b/tests/test_data_converters.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import fsspec
 import json
 from cv_pipeliner.core.data import ImageData, BboxData
-from cv_pipeliner.data_converters.coco import COCO_LabelsDataConverter
+from cv_pipeliner.data_converters.coco import COCODataConverter
 from cv_pipeliner.data_converters.brickit import BrickitDataConverter
 from cv_pipeliner.data_converters.json import JSONDataConverter
 from cv_pipeliner.data_converters.supervisely import SuperviselyDataConverter
@@ -72,11 +72,11 @@ coco_class_names = [
 
 @pytest.mark.parametrize(
     "data_convertor_cls",
-    [COCO_LabelsDataConverter, BrickitDataConverter, JSONDataConverter, SuperviselyDataConverter],
+    [COCODataConverter, BrickitDataConverter, JSONDataConverter, SuperviselyDataConverter],
 )
 def test_data_convertor(tmp_dir, data_convertor_cls):
     kwargs = {}
-    if data_convertor_cls == COCO_LabelsDataConverter:
+    if data_convertor_cls == COCODataConverter:
         kwargs = {'class_names': coco_class_names}
     data_converter = data_convertor_cls(**kwargs)
     annots = data_converter.get_annot_from_images_data(images_data)
@@ -84,7 +84,7 @@ def test_data_convertor(tmp_dir, data_convertor_cls):
     extenstion = "json"
     images_paths = []
     annots_paths = []
-    if data_convertor_cls == COCO_LabelsDataConverter:
+    if data_convertor_cls == COCODataConverter:
         annots = ['\n'.join(annot) for annot in annots]
         extenstion = "txt"
 
@@ -94,7 +94,7 @@ def test_data_convertor(tmp_dir, data_convertor_cls):
             image_path = image_data.image_path
             annot_path = tmp_dir / f"{image_data.image_path.name}.{extenstion}"
             with fsspec.open(annot_path, "w") as out:
-                if data_convertor_cls == COCO_LabelsDataConverter:
+                if data_convertor_cls == COCODataConverter:
                     out.write(annot)
                 else:
                     json.dump(annot, out)

--- a/tests/test_data_converters.py
+++ b/tests/test_data_converters.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+
+import fsspec
+import json
+from cv_pipeliner.core.data import ImageData, BboxData
+from cv_pipeliner.data_converters.coco import COCO_LabelsDataConverter
+from cv_pipeliner.data_converters.brickit import BrickitDataConverter
+from cv_pipeliner.data_converters.json import JSONDataConverter
+from cv_pipeliner.data_converters.supervisely import SuperviselyDataConverter
+
+import pytest
+from .conftest import assert_images_datas_equal
+
+test_data = Path(__file__).parent / 'test_data'
+coco_imgs = test_data / 'coco'
+
+images_data = [
+    ImageData(
+        image_path=coco_imgs/'000000000009.jpg',
+        bboxes_data=[
+            BboxData(xmin=1, ymin=187, xmax=612, ymax=473, label='bowl'),
+            BboxData(xmin=311, ymin=4, xmax=631, ymax=232, label='bowl'),
+            BboxData(xmin=249, ymin=229, xmax=565, ymax=474, label='broccoli'),
+            BboxData(xmin=0, ymin=13, xmax=434, ymax=388, label='bowl'),
+            BboxData(xmin=376, ymin=40, xmax=451, ymax=86, label='orange'),
+            BboxData(xmin=465, ymin=38, xmax=523, ymax=85, label='orange'),
+            BboxData(xmin=385, ymin=73, xmax=469, ymax=144, label='orange'),
+            BboxData(xmin=364, ymin=2, xmax=458, ymax=73, label='orange'),
+        ]
+    ),
+    ImageData(
+        image_path=coco_imgs/'000000000025.jpg',
+        bboxes_data=[
+            BboxData(xmin=385, ymin=60, xmax=600, ymax=357, label='giraffe'),
+            BboxData(xmin=53, ymin=356, xmax=185, ymax=411, label='giraffe')
+        ]
+    ),
+    ImageData(
+        image_path=coco_imgs/'000000000030.jpg',
+        bboxes_data=[
+            BboxData(xmin=204, ymin=31, xmax=459, ymax=355, label='potted plant'),
+            BboxData(xmin=237, ymin=155, xmax=403, ymax=351, label='vase')
+        ]
+    ),
+    ImageData(
+        image_path=coco_imgs/'000000000034.jpg',
+        bboxes_data=[
+            BboxData(xmin=0, ymin=20, xmax=442, ymax=399, label='zebra')
+        ]
+    ),
+    ImageData(
+        image_path=coco_imgs/'000000000036.jpg',
+        bboxes_data=[
+            BboxData(xmin=0, ymin=50, xmax=457, ymax=480, label='umbrella'),
+            BboxData(xmin=167, ymin=162, xmax=478, ymax=628, label='person')
+        ]
+    )
+]
+
+coco_class_names = [
+    'bowl',
+    'broccoli',
+    'giraffe',
+    'orange',
+    'person',
+    'potted plant',
+    'umbrella',
+    'vase',
+    'zebra'
+]
+
+
+@pytest.mark.parametrize(
+    "data_convertor_cls",
+    [COCO_LabelsDataConverter, BrickitDataConverter, JSONDataConverter, SuperviselyDataConverter],
+)
+def test_data_convertor(tmp_dir, data_convertor_cls):
+    kwargs = {}
+    if data_convertor_cls == COCO_LabelsDataConverter:
+        kwargs = {'class_names': coco_class_names}
+    data_converter = data_convertor_cls(**kwargs)
+    annots = data_converter.get_annot_from_images_data(images_data)
+
+    extenstion = "json"
+    images_paths = []
+    annots_paths = []
+    if data_convertor_cls == COCO_LabelsDataConverter:
+        annots = ['\n'.join(annot) for annot in annots]
+        extenstion = "txt"
+
+    # Разметка формата N изображений --> N файлов разметки
+    if data_convertor_cls != BrickitDataConverter:
+        for image_data, annot in zip(images_data, annots):
+            image_path = image_data.image_path
+            annot_path = tmp_dir / f"{image_data.image_path.name}.{extenstion}"
+            with fsspec.open(annot_path, "w") as out:
+                if data_convertor_cls == COCO_LabelsDataConverter:
+                    out.write(annot)
+                else:
+                    json.dump(annot, out)
+            images_paths.append(image_path)
+            annots_paths.append(annot_path)
+
+        images_data_from_annots = data_converter.get_images_data_from_annots(images_paths, annots_paths)
+
+    # Разметка формата N изображений --> 1 файл разметки
+    else:
+        annots_path = tmp_dir / f"{coco_imgs.name}-annotations.json"
+        with fsspec.open(annots_path, "w") as out:
+            json.dump(annots, out)
+        images_data_from_annots = data_converter.get_images_data_from_annots(coco_imgs, annots_path)
+
+    assert len(images_data) == len(images_data_from_annots)
+    for image_data1, image_data2 in zip(images_data, images_data_from_annots):
+        assert_images_datas_equal(image_data1, image_data2)


### PR DESCRIPTION
WIP: `0.10.0` changelog:
- `ImageData.from_json()` can now be used on paths to json files
- Added `COCODataConverter` for COCO annotations
- Added tests for `DataConverter`
- Added `utils.imagesize` (taken from https://github.com/shibukawa/imagesize_py), with support of fsspec file-like objects
- Added DetectionModel for YOLOv5 in `inference_models.detection.yolov5`
- Pipeline's model logging level changed from INFO to DEBUG.
- Add `FiftyOneSession` for simplier using with FiftyOne (in `utils.fiftyone`)
- Added function `utils.images_data.flatten_additional_bboxes_data_in_image_data`
- `DetectionInferencer`, `ClassificationInferencer` and `PipelineInferencer` now can accept list of `ImageData` (of `BboxData` for `ClassificationInferencer`), with `batch_size_default=16` for Detection/Pipeline and `batch_size_default=32` for Classification
- Add method `.load_detection_inferencer()` to class `DetectionModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.DetectionInferencer`
- Add method `.load_classification_inferencer()` to class `ClassificationModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.ClassificationInferencer`
- Add method `.load_pipeline_inferencer()` to class `PipelineModelSpec` that loads model and returns corresponding `cv_pipeliner.inferencers.PipelineInferencer`
- Argument `classification_model_spec` is now `None` by default for `PipelineModelSpec`
- Add argument `return_as_pil_image: bool` set default as `False` in `visualize_image_data`, `visualize_images_data_side_by_side` and `visualize_image_data_matching_side_by_side`, that returns images as `PIL.Image.Image`
