### PR TITLE
0.11.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.11.1
+- Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`
+- Add cliping when `cv_pipeliner.utils.images.denormalize_bboxes`
+
 # 0.11.0
 - Added new inference models: `KeypointsRegressorModel`, `YOLOv5_DetectionModel` and `Tensorflow_EmbedderModel`
 - Name of detectron2's models `Pytorch_DetectionModel` changed to `Detectron2_DetectionModel`

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 from cv_pipeliner.core.data import ImageData, BboxData
 from cv_pipeliner.batch_generators.image_data import BatchGeneratorImageData

--- a/cv_pipeliner/inference_models/detection/detectron2.py
+++ b/cv_pipeliner/inference_models/detection/detectron2.py
@@ -232,7 +232,6 @@ class Detectron2_DetectionModel(DetectionModel):
             xmin, ymin, xmax, ymax = bbox
             if (
                 xmax - xmin > 0 and ymax - ymin > 0 and
-                xmin >= 0 and ymin >= 0 and xmax <= width-1 and ymax <= height-1 and
                 (xmin, ymin, xmax, ymax) not in bboxes_set
             ):
                 bboxes_set.add((xmin, ymin, xmax, ymax))

--- a/cv_pipeliner/inference_models/detection/object_detection_api.py
+++ b/cv_pipeliner/inference_models/detection/object_detection_api.py
@@ -347,7 +347,6 @@ class ObjectDetectionAPI_DetectionModel(DetectionModel):
             xmin, ymin, xmax, ymax = bbox
             if (
                 xmax - xmin > 0 and ymax - ymin > 0 and
-                xmin >= 0 and ymin >= 0 and xmax <= width-1 and ymax <= height-1 and
                 (xmin, ymin, xmax, ymax) not in bboxes_set
             ):
                 bboxes_set.add((xmin, ymin, xmax, ymax))

--- a/cv_pipeliner/inference_models/detection/yolov5.py
+++ b/cv_pipeliner/inference_models/detection/yolov5.py
@@ -271,7 +271,6 @@ class YOLOv5_DetectionModel(DetectionModel):
             xmin, ymin, xmax, ymax = bbox
             if (
                 xmax - xmin > 0 and ymax - ymin > 0 and
-                xmin >= 0 and ymin >= 0 and xmax <= width-1 and ymax <= height-1 and
                 (xmin, ymin, xmax, ymax) not in bboxes_set
             ):
                 bboxes_set.add((xmin, ymin, xmax, ymax))

--- a/cv_pipeliner/utils/images.py
+++ b/cv_pipeliner/utils/images.py
@@ -32,6 +32,8 @@ def denormalize_bboxes(bboxes: List[Tuple[float, float, float, float]],
     bboxes[:, [0, 2]] = bboxes[:, [0, 2]] * image_width
     bboxes[:, [1, 3]] = bboxes[:, [1, 3]] * image_height
     bboxes = bboxes.round().astype(int)
+    bboxes[:, [0, 2]] = np.clip(bboxes[:, [0, 2]], 0, image_width-1)
+    bboxes[:, [1, 3]] = np.clip(bboxes[:, [1, 3]], 0, image_height-1)
     return bboxes
 
 

--- a/cv_pipeliner/utils/images_datas.py
+++ b/cv_pipeliner/utils/images_datas.py
@@ -157,6 +157,7 @@ def _rotate_bbox_data90(
 def rotate_image_data(
     image_data: ImageData,
     angle: float,
+    warp_flags: Optional[int] = None,
     border_mode: Optional[int] = None,
     border_value: Tuple[int, int, int] = None
 ):
@@ -199,7 +200,8 @@ def rotate_image_data(
         rotation_mat[1, 2] += bound_h/2 - image_center[1]
 
         rotated_image = cv2.warpAffine(
-            image, rotation_mat, (bound_w, bound_h), borderMode=border_mode, borderValue=border_value
+            image, rotation_mat, (bound_w, bound_h), flags=warp_flags,
+            borderMode=border_mode, borderValue=border_value
         )
         new_height, new_width, _ = rotated_image.shape
         rotated_image_data = copy.deepcopy(image_data)


### PR DESCRIPTION
# 0.11.1
- Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`
- Add cliping when `cv_pipeliner.utils.images.denormalize_bboxes`. **This may change metrics to the better values.**