### PR TITLE
0.12.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.12.0
+- Fix `bbox_data.json()` when values are written as np.int64
+- Add `COCOLabelsFile` for datapipe
+
 # 0.11.1
 - Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`
 - Add cliping when `cv_pipeliner.utils.images.denormalize_bboxes`

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@
 - Fixs in `parse_rectangle_labels_to_bbox_data` and `convert_image_data_to_rectangle_labels` in `utils.label_studio`
 - Add new argument `thumbnail_size` in `cv_pipeliner.visualize_image_data`
 - `ImageData.from_json` and `BboxData.from_json` now have arguments `image_data_cls` and `bbox_data_cls` for parsing JSON of child's classes.
+- Add `threshold_score` in `utils.images_data.non_max_suppression_image_data_using_tf`
+- `thumbnail_image` and `thumbnail_image_data` accepts also `int`, meaning size of `(int, int)`
+- `YOLOv5_TFLite_ModelSpec` is now more stable
+- Added `bbox_data.area` for calculating bbox's area
+- The function `cv_pipeliner.utils.images_data.non_max_suppression_image_data` is refactored and works faster
+
 
 # 0.11.1
 - Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 - Fix `bbox_data.json()` when values are written as np.int64
 - Add `utils.datapipe.COCOLabelsFile` for datapipe
 - Add argument `score_threshold` in `utils.images_datas.non_max_suppression_image_data_using_tf`
+- Fixs in `parse_rectangle_labels_to_bbox_data` and `convert_image_data_to_rectangle_labels` in `utils.label_studio`
+- Add new argument `thumbnail_size` in `cv_pipeliner.visualize_image_data`
+- `ImageData.from_json` and `BboxData.from_json` now have arguments `image_data_cls` and `bbox_data_cls` for parsing JSON of child's classes.
 
 # 0.11.1
 - Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # 0.12.0
 - Fix `bbox_data.json()` when values are written as np.int64
-- Add `COCOLabelsFile` for datapipe
+- Add `utils.datapipe.COCOLabelsFile` for datapipe
+- Add argument `score_threshold` in `utils.images_datas.non_max_suppression_image_data_using_tf`
 
 # 0.11.1
 - Add argument `warp_flags` in `cv_pipeliner.utils.images_data.rotate_image_data`

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -17,7 +17,7 @@ from cv_pipeliner.utils.images_datas import (
     apply_perspective_transform_to_image_data,
     thumbnail_image_data, non_max_suppression_image_data, uncrop_bboxes_data,
     resize_image_data, split_image_by_grid, flatten_additional_bboxes_data_in_image_data,
-    non_max_suppression_image_data_using_tf, get_image_data_with_recursive_bboxes_data
+    non_max_suppression_image_data_using_tf
 )
 from cv_pipeliner.inference_models.detection.object_detection_api import (
     ObjectDetectionAPI_KFServing, ObjectDetectionAPI_ModelSpec, ObjectDetectionAPI_TFLite_ModelSpec,

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -17,7 +17,7 @@ from cv_pipeliner.utils.images_datas import (
     apply_perspective_transform_to_image_data,
     thumbnail_image_data, non_max_suppression_image_data, uncrop_bboxes_data,
     resize_image_data, split_image_by_grid, flatten_additional_bboxes_data_in_image_data,
-    non_max_suppression_image_data_using_tf
+    non_max_suppression_image_data_using_tf, get_image_data_with_recursive_bboxes_data
 )
 from cv_pipeliner.inference_models.detection.object_detection_api import (
     ObjectDetectionAPI_KFServing, ObjectDetectionAPI_ModelSpec, ObjectDetectionAPI_TFLite_ModelSpec,

--- a/cv_pipeliner/core/data.py
+++ b/cv_pipeliner/core/data.py
@@ -234,10 +234,10 @@ class BboxData:
 
     def json(self, include_image_path: bool = True) -> Dict:
         result_json = {
-            'xmin': self.xmin if isinstance(self.xmin, int) else round(self.xmin, 6),
-            'ymin': self.ymin if isinstance(self.ymin, int) else round(self.ymin, 6),
-            'xmax': self.xmax if isinstance(self.xmax, int) else round(self.xmax, 6),
-            'ymax': self.ymax if isinstance(self.ymax, int) else round(self.ymax, 6),
+            'xmin': int(self.xmin) if isinstance(self.xmin, (int, np.int64)) else round(self.xmin, 6),
+            'ymin': int(self.ymin) if isinstance(self.ymin, (int, np.int64)) else round(self.ymin, 6),
+            'xmax': int(self.xmax) if isinstance(self.xmax, (int, np.int64)) else round(self.xmax, 6),
+            'ymax': int(self.ymax) if isinstance(self.ymax, (int, np.int64)) else round(self.ymax, 6),
         }
         if include_image_path:
             result_json['image_path'] = get_image_path_as_str(self.image_path)

--- a/cv_pipeliner/core/data.py
+++ b/cv_pipeliner/core/data.py
@@ -121,6 +121,10 @@ class BboxData:
         width, height = self.get_image_size()
         return self.xmin / width, self.ymin / height, self.xmax / width, self.ymax / height
 
+    @property
+    def area(self) -> int:
+        return (self.xmax - self.xmin + 1) * (self.ymax - self.ymin + 1)
+
     def coords_with_offset(
         self,
         xmin_offset: Union[int, float] = 0,

--- a/cv_pipeliner/data_converters/coco.py
+++ b/cv_pipeliner/data_converters/coco.py
@@ -1,4 +1,3 @@
-from turtle import width
 from typing import Union, Dict, List
 from pathlib import Path
 

--- a/cv_pipeliner/inference_models/detection/object_detection_api.py
+++ b/cv_pipeliner/inference_models/detection/object_detection_api.py
@@ -52,7 +52,7 @@ class ObjectDetectionAPI_TFLite_ModelSpec(DetectionModelSpec):
     model_path: Union[str, Path]
     bboxes_output_index: Union[int, str]
     scores_output_index: Union[int, str]
-    classes_output_index: Optional[Union[int, str]]
+    classes_output_index: Union[int, str]
     multiclasses_scores_output_index: Optional[Union[int, str]] = None
     class_names: Optional[List[str]] = None
     preprocess_input: Union[Callable[[List[np.ndarray]], np.ndarray], str, Path, None] = None

--- a/cv_pipeliner/utils/datapipe.py
+++ b/cv_pipeliner/utils/datapipe.py
@@ -1,6 +1,8 @@
 import json
+import pathlib
 import numpy as np
-from typing import Any, Dict, IO, Tuple
+import fsspec
+from typing import Any, Dict, IO, Tuple, List
 
 from datapipe.store.filedir import ItemStoreFileAdapter
 from cv_pipeliner.core.data import ImageData
@@ -49,3 +51,26 @@ class GetImageSizeFile(ItemStoreFileAdapter):
 
     def dump(self, obj: Dict[str, Tuple[int, int]], f: IO) -> None:
         raise NotImplementedError
+
+
+class COCOLabelsFile(ItemStoreFileAdapter):
+    mode = 'b'
+
+    def __init__(self, class_names: List[str], img_format: str):
+        from cv_pipeliner.data_converters.coco import COCODataConverter
+        self.coco_converter = COCODataConverter(class_names)
+        self.img_format = img_format
+
+    def load(self, f: fsspec.core.OpenFile) -> Dict[str, Tuple[int, int]]:
+        filepath = pathlib(f.path)
+        assert filepath.parent.name == 'labels'
+        image_path = filepath.parent.parent / 'images' / f"{filepath.stem}.{self.img_format}"
+        image_data = self.coco_converter.get_image_data_from_annot(
+            image_path=f"{f.fs.protocol}://{image_path}", annot=f
+        )
+        return {'image_size': image_data}
+
+    def dump(self, obj: Dict[str, Tuple[int, int]], f: fsspec.core.OpenFile) -> None:
+        image_data: ImageData = obj['image_data']
+        coco_data = self.coco_converter.get_annot_from_image_data(image_data)
+        f.write('\n'.join(coco_data).encode())

--- a/cv_pipeliner/utils/images.py
+++ b/cv_pipeliner/utils/images.py
@@ -512,14 +512,15 @@ def draw_quadrangle_on_image(
     return image
 
 
-def get_thumbnail_resize(image: Image, size: Tuple[int, int]) -> Tuple[int, int]:
-    x, y = map(math.floor, size)
+def get_thumbnail_resize(input_size: Tuple[int, int], target_size: Tuple[int, int]) -> Tuple[int, int]:
+    # input_size = (width, height)
+    x, y = map(math.floor, target_size)
 
     def round_aspect(number, key):
         return max(min(math.floor(number), math.ceil(number), key=key), 1)
 
     # preserve aspect ratio
-    aspect = image.width / image.height
+    aspect = input_size[0] / input_size[1]
     if x / y >= aspect:
         x = round_aspect(y * aspect, key=lambda n: abs(aspect - n / y))
     else:
@@ -532,7 +533,7 @@ def get_thumbnail_resize(image: Image, size: Tuple[int, int]) -> Tuple[int, int]
 
 def thumbnail_image(image: np.ndarray, size: Tuple[int, int], resample: Optional[int] = None) -> np.ndarray:
     image = Image.fromarray(image)
-    new_width, new_height = get_thumbnail_resize(image, size)
+    new_width, new_height = get_thumbnail_resize((image.width, image.height), size)
     image = image.resize((new_width, new_height), resample=resample)
     image = np.array(image)
     return image

--- a/cv_pipeliner/utils/images_datas.py
+++ b/cv_pipeliner/utils/images_datas.py
@@ -6,7 +6,6 @@ import cv2
 from PIL import Image
 
 from cv_pipeliner.core.data import ImageData, BboxData
-from cv_pipeliner.metrics.image_data_matching import intersection_over_union
 from cv_pipeliner.utils.images import concat_images, get_thumbnail_resize
 
 
@@ -528,46 +527,41 @@ def apply_perspective_transform_to_image_data(
 
 def non_max_suppression_image_data(
     image_data: ImageData,
-    iou: float
+    iou: float,
+    score_threshold: float = float('-inf')
 ) -> ImageData:
+    """
+        Taken from https://towardsdatascience.com/non-maxima-suppression-139f7e00f0b5
+    """
     image_data = copy.deepcopy(image_data)
-    current_bboxes_data = image_data.bboxes_data.copy()
-    new_bboxes_data = []
-    while len(current_bboxes_data) != 0:
-        current_bbox_data = current_bboxes_data[0]
-        success = True
-        if len(current_bboxes_data) > 1:
-            for idx, bbox_data in enumerate(current_bboxes_data):
-                if idx == 0:
-                    continue
-                bbox_iou = intersection_over_union(current_bbox_data, bbox_data)
+    boxes = np.array([bbox_data.coords for bbox_data in image_data.bboxes_data])
+    x1 = boxes[:, 0]  # x coordinate of the top-left corner
+    y1 = boxes[:, 1]  # y coordinate of the top-left corner
+    x2 = boxes[:, 2]  # x coordinate of the bottom-right corner
+    y2 = boxes[:, 3]  # y coordinate of the bottom-right corner
+    # compute the area of the bounding boxes and sort the bounding
+    # boxes by the bottom-right y-coordinate of the bounding box
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)  # We have a least a box of one pixel, therefore the +1
+    indices = np.arange(len(boxes))
+    for i, bbox_data in enumerate(image_data.bboxes_data):
+        temp_indices = indices[indices != i]
+        xx1 = np.maximum(bbox_data.xmin, boxes[temp_indices, 0])
+        yy1 = np.maximum(bbox_data.ymin, boxes[temp_indices, 1])
+        xx2 = np.minimum(bbox_data.xmax, boxes[temp_indices, 2])
+        yy2 = np.minimum(bbox_data.ymax, boxes[temp_indices, 3])
+        w = np.maximum(0, xx2 - xx1 + 1)
+        h = np.maximum(0, yy2 - yy1 + 1)
+        # compute the ratio of overlap
+        overlap = (w * h) / areas[temp_indices]
+        if np.any(overlap) > iou:
+            indices = indices[indices != i]
 
-                if bbox_iou >= iou:
-                    pairs_bboxes_data = [bbox_data, current_bbox_data]
-                    pairs_scores = [
-                        possible_bbox_data.detection_score if possible_bbox_data.detection_score is not None else 1.
-                        for possible_bbox_data in pairs_bboxes_data
-                    ]
-                    top_score_idx = np.argmax(pairs_scores)
-                    current_bboxes_data.pop(idx)
-                    current_bboxes_data.pop(0)
-                    current_bboxes_data.append(BboxData(
-                        xmin=min(bbox_data.xmin, current_bbox_data.xmin),
-                        ymin=min(bbox_data.ymin, current_bbox_data.ymin),
-                        xmax=max(bbox_data.xmax, current_bbox_data.xmax),
-                        ymax=max(bbox_data.ymax, current_bbox_data.ymax),
-                        detection_score=pairs_bboxes_data[top_score_idx].detection_score,
-                        label=pairs_bboxes_data[top_score_idx].label,
-                        keypoints=pairs_bboxes_data[top_score_idx].keypoints,
-                        additional_bboxes_data=pairs_bboxes_data[top_score_idx].additional_bboxes_data,
-                        additional_info=pairs_bboxes_data[top_score_idx].additional_info
-                    ))
-                    success = False
-                    break
-        if success:
-            new_bboxes_data.append(current_bboxes_data.pop(0))
-
-    image_data.bboxes_data = new_bboxes_data
+    image_data.bboxes_data = [image_data.bboxes_data[i] for i in indices]
+    if score_threshold is not None:
+        image_data.bboxes_data = [
+            bbox_data for bbox_data in image_data.bboxes_data
+            if (bbox_data.detection_score is None) or (bbox_data.detection_score >= score_threshold)
+        ]
     image_data.image_path = image_data.image_path
     image_data.image = image_data.image
     return image_data

--- a/cv_pipeliner/utils/images_datas.py
+++ b/cv_pipeliner/utils/images_datas.py
@@ -574,7 +574,8 @@ def non_max_suppression_image_data(
 
 def non_max_suppression_image_data_using_tf(
     image_data: ImageData,
-    iou: float
+    iou: float,
+    score_threshold: float = float('-inf')
 ) -> ImageData:
     import tensorflow as tf
     image_data = copy.deepcopy(image_data)
@@ -585,7 +586,7 @@ def non_max_suppression_image_data_using_tf(
         for bbox_data in image_data.bboxes_data
     ]
     scores = [bbox_data.detection_score if bbox_data.detection_score is not None else 1. for bbox_data in image_data.bboxes_data]
-    result = tf.image.non_max_suppression(bboxes, scores, len(image_data.bboxes_data), iou_threshold=iou)
+    result = tf.image.non_max_suppression(bboxes, scores, len(image_data.bboxes_data), iou_threshold=iou, score_threshold=score_threshold)
     image_data.bboxes_data = [image_data.bboxes_data[i] for i in result.numpy()]
     return image_data
 

--- a/cv_pipeliner/utils/label_studio.py
+++ b/cv_pipeliner/utils/label_studio.py
@@ -29,10 +29,10 @@ def parse_rectangle_labels_to_bbox_data(
     ymin = max(0, min([y for (x, y) in rotated_points]))
     xmax = max([x for (x, y) in rotated_points])
     ymax = max([y for (x, y) in rotated_points])
-    xmin = max(0, min(original_width, xmin))
-    ymin = max(0, min(original_height, ymin))
-    xmax = max(0, min(original_width, xmax))
-    ymax = max(0, min(original_height, ymax))
+    xmin = max(0, min(original_width-1, xmin))
+    ymin = max(0, min(original_height-1, ymin))
+    xmax = max(0, min(original_width-1, xmax))
+    ymax = max(0, min(original_height-1, ymax))
     bbox_data = BboxData(
         xmin=xmin,
         ymin=ymin,
@@ -48,10 +48,7 @@ def convert_image_data_to_rectangle_labels(
     from_name: str,
     to_name: str,
 ) -> Dict:
-    if image_data.image_path is not None:
-        im_width, im_height = imagesize.get(image_data.image_path)
-    else:
-        im_height, im_width, _ = image_data.open_image().shape
+    im_width, im_height = image_data.get_image_size()
     rectangle_labels = []
     for bbox_data in image_data.bboxes_data:
         rectangle_labels.append({

--- a/cv_pipeliner/visualizers/core/image_data.py
+++ b/cv_pipeliner/visualizers/core/image_data.py
@@ -297,15 +297,15 @@ def visualize_image_data(
     use_labels: bool = False,
     score_type: Literal['detection', 'classification'] = None,
     filter_by_labels: List[str] = None,
-    known_labels: List[str] = None,
+    known_labels: Optional[List[str]] = None,
     draw_base_labels_with_given_label_to_base_label_image: Callable[[str], np.ndarray] = None,
     keypoints_radius: int = 5,
     include_additional_bboxes_data: bool = False,
     additional_bboxes_data_depth: Optional[int] = None,
     fontsize: int = 24,
     thickness: int = 4,
-    return_as_pil_image: bool = False,
-    thumbnail_size: Optional[Union[int, Tuple[int, int]]] = None
+    thumbnail_size: Optional[Union[int, Tuple[int, int]]] = None,
+    return_as_pil_image: bool = False
 ) -> Union[np.ndarray, Image.Image]:
 
     if thumbnail_size is not None:
@@ -392,20 +392,22 @@ def visualize_images_data_side_by_side(
     score_type2: Literal['detection', 'classification'] = None,
     filter_by_labels1: List[str] = None,
     filter_by_labels2: List[str] = None,
-    known_labels: List[str] = [],
+    known_labels: Optional[List[str]] = None,
     draw_base_labels_with_given_label_to_base_label_image: Callable[[str], np.ndarray] = None,
     overlay: bool = False,
+    keypoints_radius: int = 5,
     include_additional_bboxes_data: bool = False,
     additional_bboxes_data_depth: Optional[int] = None,
     fontsize: int = 24,
     thickness: int = 4,
+    thumbnail_size: Optional[Union[int, Tuple[int, int]]] = None,
     return_as_pil_image: bool = False
 ) -> Union[np.ndarray, Image.Image]:
 
     if overlay:
         image_data1 = copy.deepcopy(image_data1)
         image_data2 = copy.deepcopy(image_data2)
-        for image_data, tag in [(image_data1, 'true'), (image_data2, 'pred')]:
+        for image_data, tag in [(image_data1, 'left'), (image_data2, 'right')]:
             for bbox_data in image_data.bboxes_data:
                 bbox_data.label = f"{bbox_data.label} [{tag}]"
 
@@ -418,8 +420,10 @@ def visualize_images_data_side_by_side(
         draw_base_labels_with_given_label_to_base_label_image=draw_base_labels_with_given_label_to_base_label_image,
         include_additional_bboxes_data=include_additional_bboxes_data,
         additional_bboxes_data_depth=additional_bboxes_data_depth,
+        keypoints_radius=keypoints_radius,
         fontsize=fontsize,
-        thickness=thickness
+        thickness=thickness,
+        thumbnail_size=thumbnail_size
     )
     pred_ann_image = visualize_image_data(
         image_data=image_data2,
@@ -430,8 +434,10 @@ def visualize_images_data_side_by_side(
         draw_base_labels_with_given_label_to_base_label_image=draw_base_labels_with_given_label_to_base_label_image,
         include_additional_bboxes_data=include_additional_bboxes_data,
         additional_bboxes_data_depth=additional_bboxes_data_depth,
+        keypoints_radius=keypoints_radius,
         fontsize=fontsize,
-        thickness=thickness
+        thickness=thickness,
+        thumbnail_size=thumbnail_size
     )
 
     if overlay:

--- a/cv_pipeliner/visualizers/core/image_data_matching.py
+++ b/cv_pipeliner/visualizers/core/image_data_matching.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Callable, Union
+from typing import List, Literal, Callable, Optional, Tuple, Union
 
 import numpy as np
 from PIL import Image
@@ -80,9 +80,15 @@ def visualize_image_data_matching_side_by_side(
     pred_score_type: Literal['detection', 'classification'] = None,
     true_filter_by_error_types: List[error_type] = ['TP', 'FP', 'FN', 'TP (extra bbox)', 'FP (extra bbox)'],
     pred_filter_by_error_types: List[error_type] = ['TP', 'FP', 'FN', 'TP (extra bbox)', 'FP (extra bbox)'],
+    known_labels: Optional[List[str]] = None,
     draw_base_labels_with_given_label_to_base_label_image: Callable[[str], np.ndarray] = None,
-    known_labels: List[str] = [],
-    label: str = None,
+    overlay: bool = False,
+    keypoints_radius: int = 5,
+    include_additional_bboxes_data: bool = False,
+    additional_bboxes_data_depth: Optional[int] = None,
+    fontsize: int = 24,
+    thickness: int = 4,
+    thumbnail_size: Optional[Union[int, Tuple[int, int]]] = None,    label: str = None,
     return_as_pil_image: bool = False
 ) -> Union[np.ndarray, Image.Image]:
 
@@ -113,5 +119,12 @@ def visualize_image_data_matching_side_by_side(
         filter_by_labels2=pred_filter_by_labels,
         known_labels=known_labels,
         draw_base_labels_with_given_label_to_base_label_image=draw_base_labels_with_given_label_to_base_label_image,
+        overlay=overlay,
+        keypoints_radius=keypoints_radius,
+        include_additional_bboxes_data=include_additional_bboxes_data,
+        additional_bboxes_data_depth=additional_bboxes_data_depth,
+        fontsize=fontsize,
+        thickness=thickness,
+        thumbnail_size=thumbnail_size,
         return_as_pil_image=return_as_pil_image
     )


### PR DESCRIPTION
# 0.12.0
- Fix `bbox_data.json()` when values are written as np.int64
- Add `utils.datapipe.COCOLabelsFile` for datapipe
- Add argument `score_threshold` in `utils.images_datas.non_max_suppression_image_data_using_tf`
- Fixs in `parse_rectangle_labels_to_bbox_data` and `convert_image_data_to_rectangle_labels` in `utils.label_studio`
- Add new argument `thumbnail_size` in `cv_pipeliner.visualize_image_data`
- `ImageData.from_json` and `BboxData.from_json` now have arguments `image_data_cls` and `bbox_data_cls` for parsing JSON of child's classes.
- Add `threshold_score` in `utils.images_data.non_max_suppression_image_data_using_tf`
- `thumbnail_image` and `thumbnail_image_data` accepts also `int`, meaning size of `(int, int)`
- `YOLOv5_TFLite_ModelSpec` is now more stable
- Added `bbox_data.area` for calculating bbox's area
- The function `cv_pipeliner.utils.images_data.non_max_suppression_image_data` is refactored and works faster
