### PR TITLE
0.15.3

### DIFF
--- a/cv_pipeliner/inference_models/classification/tensorflow.py
+++ b/cv_pipeliner/inference_models/classification/tensorflow.py
@@ -36,7 +36,7 @@ class TensorFlow_ClassificationModelSpec_TFServing(ClassificationModelSpec):
     url: str
     input_type: Literal["image_tensor", "float_image_tensor", "encoded_image_string_tensor"]
     input_name: str
-    input_size: Union[Tuple[int, int], List[int]]
+    input_size: Optional[Union[Tuple[Optional[int], Optional[int]], List[Optional[int]]]]
     class_names: Union[List[str], str, Path]
     preprocess_input: Union[Callable[[List[np.ndarray]], np.ndarray], str, Path, None] = None
 

--- a/cv_pipeliner/inference_models/classification/tensorflow.py
+++ b/cv_pipeliner/inference_models/classification/tensorflow.py
@@ -19,7 +19,7 @@ from cv_pipeliner.utils.images import get_image_b64
 
 
 class TensorFlow_ClassificationModelSpec(ClassificationModelSpec):
-    input_size: Union[Tuple[int, int], List[int]]
+    input_size: Optional[Union[Tuple[Optional[int], Optional[int]], List[Optional[int]]]]
     class_names: Union[List[str], str, Path]
     model_path: Union[str, Pathy]  # can be also tf.keras.Model
     saved_model_type: Literal["tf.saved_model", "tf.keras", "tf.keras.Model", "tflite", "tflite_one_image_per_batch"]


### PR DESCRIPTION
- Fix `input_size` typing for pydantic in `TensorFlow_ClassificationModelSpec` and `TensorFlow_ClassificationModelSpec_TFServing`