### PR TITLE
0.20.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.20.2
+- `split_image_data_by_grid` is refactored fully and now accepts `allow_large_coords`, `split_by_grid_minimum_size`, `minimum_crop_intersection_area` and `minimum_relative_size_of_inner_bboxes` arguments to control which bboxes will be included in crops when image is splitted by grid.
+- Fix `visualize_image_data` when BboxData doen't have source image, but ImageData has.
+
 # 0.20.1
 - Added new argument `ignore_classes` in `image_data.utils.non_max_suppression_image_data_using_tf`
 

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -42,7 +42,12 @@ from cv_pipeliner.inferencers.keypoints_regressor import KeypointsRegressorInfer
 from cv_pipeliner.inferencers.pipeline import PipelineInferencer
 from cv_pipeliner.metrics.classification import get_df_classification_metrics
 from cv_pipeliner.metrics.detection import get_df_detection_metrics
-from cv_pipeliner.metrics.image_data_matching import BboxDataMatching, ImageDataMatching
+from cv_pipeliner.metrics.image_data_matching import (
+    BboxDataMatching,
+    ImageDataMatching,
+    intersection_over_union,
+    pairwise_intersection_over_union,
+)
 from cv_pipeliner.metrics.pipeline import get_df_pipeline_metrics
 from cv_pipeliner.utils.fiftyone import FifyOneSession
 from cv_pipeliner.utils.images import (

--- a/cv_pipeliner/__init__.py
+++ b/cv_pipeliner/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.0"
+__version__ = "0.20.2"
 
 from cv_pipeliner.batch_generators.bbox_data import BatchGeneratorBboxData
 from cv_pipeliner.batch_generators.image_data import BatchGeneratorImageData

--- a/cv_pipeliner/utils/datapipe.py
+++ b/cv_pipeliner/utils/datapipe.py
@@ -352,19 +352,21 @@ class FiftyOneImagesDataTableStore(TableStore):
     def read_rows(self, idx: IndexDF = None, read_data: bool = True) -> DataDF:
         df_sample = self._get_df_sample(idx=idx)
         df_sample["image_data"] = df_sample["sample"].apply(
-            lambda sample: self.fo_session.convert_sample_to_image_data(
-                sample=sample,
-                fo_detections_label=self.fo_detections_label,
-                fo_classification_label=self.fo_classification_label,
-                fo_keypoints_label=self.fo_keypoints_label,
-                mapping_filepath=self.inverse_mapping_filepath,
-                additional_info_keys_in_fo_detections=self.additional_info_keys_in_fo_detections,
-                additional_info_keys_in_sample=self.additional_info_keys_in_sample,
-                image_data_cls=self.image_data_cls,
-                bbox_data_cls=self.bbox_data_cls,
+            lambda sample: (
+                self.fo_session.convert_sample_to_image_data(
+                    sample=sample,
+                    fo_detections_label=self.fo_detections_label,
+                    fo_classification_label=self.fo_classification_label,
+                    fo_keypoints_label=self.fo_keypoints_label,
+                    mapping_filepath=self.inverse_mapping_filepath,
+                    additional_info_keys_in_fo_detections=self.additional_info_keys_in_fo_detections,
+                    additional_info_keys_in_sample=self.additional_info_keys_in_sample,
+                    image_data_cls=self.image_data_cls,
+                    bbox_data_cls=self.bbox_data_cls,
+                )
+                if read_data
+                else {}
             )
-            if read_data
-            else {}
         )
         return df_sample
 

--- a/cv_pipeliner/utils/images.py
+++ b/cv_pipeliner/utils/images.py
@@ -213,16 +213,16 @@ def concat_images(
             new_image[:background_edge_width, :wa, :] = background_color_a
             new_image[-background_edge_width:, :wa, :] = background_color_a
             new_image[:, :background_edge_width, :] = background_color_a
-            new_image[
-                :, wa + between_edge_width - (background_edge_width - 1) : wa + between_edge_width, :
-            ] = background_color_a
+            new_image[:, wa + between_edge_width - (background_edge_width - 1) : wa + between_edge_width, :] = (
+                background_color_a
+            )
         if background_color_b is not None:
             new_image[:background_edge_width, wa:, :] = background_color_b
             new_image[-background_edge_width:, wa:, :] = background_color_b
             new_image[:, -background_edge_width:, :] = background_color_b
-            new_image[
-                :, wa + between_edge_width : wa + between_edge_width + (background_edge_width - 1), :
-            ] = background_color_b
+            new_image[:, wa + between_edge_width : wa + between_edge_width + (background_edge_width - 1), :] = (
+                background_color_b
+            )
     elif how == "vertically":
         max_width = np.max([wa, wb])
         total_height = ha + hb + between_edge_width
@@ -242,16 +242,16 @@ def concat_images(
             new_image[:ha, :background_edge_width, :] = background_color_a
             new_image[:ha, -background_edge_width:, :] = background_color_a
             new_image[:background_edge_width, :, :] = background_color_a
-            new_image[
-                ha + between_edge_width - (background_edge_width - 1) : ha + between_edge_width, :, :
-            ] = background_color_a
+            new_image[ha + between_edge_width - (background_edge_width - 1) : ha + between_edge_width, :, :] = (
+                background_color_a
+            )
         if background_color_b is not None:
             new_image[ha:, :background_edge_width, :] = background_color_b
             new_image[ha:, -background_edge_width:, :] = background_color_b
             new_image[-background_edge_width:, :, :] = background_color_b
-            new_image[
-                ha + between_edge_width : ha + between_edge_width + (background_edge_width - 1), :, :
-            ] = background_color_b
+            new_image[ha + between_edge_width : ha + between_edge_width + (background_edge_width - 1), :, :] = (
+                background_color_b
+            )
     else:
         raise ValueError("Parametr how must be 'horizontally' or 'vertically'")
 

--- a/cv_pipeliner/utils/object_detection_api.py
+++ b/cv_pipeliner/utils/object_detection_api.py
@@ -198,13 +198,13 @@ def set_config(
 
     configs["train_config"].max_number_of_boxes = max_number_of_boxes
     if total_steps is not None:
-        configs[
-            "train_config"
-        ].optimizer.adam_optimizer.learning_rate.cosine_decay_learning_rate.total_steps = total_steps
+        configs["train_config"].optimizer.adam_optimizer.learning_rate.cosine_decay_learning_rate.total_steps = (
+            total_steps
+        )
     if warmup_steps is not None:
-        configs[
-            "train_config"
-        ].optimizer.adam_optimizer.learning_rate.cosine_decay_learning_rate.warmup_steps = warmup_steps
+        configs["train_config"].optimizer.adam_optimizer.learning_rate.cosine_decay_learning_rate.warmup_steps = (
+            warmup_steps
+        )
     if num_steps is not None:
         configs["train_config"].num_steps = num_steps
 

--- a/cv_pipeliner/visualizers/core/image_data.py
+++ b/cv_pipeliner/visualizers/core/image_data.py
@@ -446,7 +446,10 @@ def visualize_image_data(
         known_labels = list(set(labels))
     k_keypoints = [bbox_data.keypoints for bbox_data in bboxes_data]
     bboxes = np.array(
-        [bbox_data.coords_with_offset(xmin_offset, ymin_offset, xmax_offset, ymax_offset, source_image=image) for bbox_data in bboxes_data]
+        [
+            bbox_data.coords_with_offset(xmin_offset, ymin_offset, xmax_offset, ymax_offset, source_image=image)
+            for bbox_data in bboxes_data
+        ]
     )
     angles = np.array([0.0 for _ in bboxes_data])
     if score_type == "detection":

--- a/cv_pipeliner/visualizers/core/image_data.py
+++ b/cv_pipeliner/visualizers/core/image_data.py
@@ -446,7 +446,7 @@ def visualize_image_data(
         known_labels = list(set(labels))
     k_keypoints = [bbox_data.keypoints for bbox_data in bboxes_data]
     bboxes = np.array(
-        [bbox_data.coords_with_offset(xmin_offset, ymin_offset, xmax_offset, ymax_offset) for bbox_data in bboxes_data]
+        [bbox_data.coords_with_offset(xmin_offset, ymin_offset, xmax_offset, ymax_offset, source_image=image) for bbox_data in bboxes_data]
     )
     angles = np.array([0.0 for _ in bboxes_data])
     if score_type == "detection":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cv_pipeliner"
-version = "0.20.1"
+version = "0.20.2"
 description = ""
 authors = [
     "bobokvsky <alexander.kozlovsky.m@gmail.com>",


### PR DESCRIPTION
# 0.20.2
- `split_image_data_by_grid` is refactored fully and now accepts `allow_large_coords`, `split_by_grid_minimum_size`, `minimum_crop_intersection_area` and `minimum_relative_size_of_inner_bboxes` arguments to control which bboxes will be included in crops when image is splitted by grid.
- Fix `visualize_image_data` when BboxData doen't have source image, but ImageData has.
