### PR TITLE
Фикс get_image_size()

### DIFF
--- a/cv_pipeliner/utils/imagesize.py
+++ b/cv_pipeliner/utils/imagesize.py
@@ -27,7 +27,7 @@ def get_image_size(filepath: "bytes_or_path", exif_transpose: bool = True) -> Tu
     elif isinstance(filepath, fsspec.core.OpenFile):  # file-like object
         fhandle = filepath.__enter__()
     else:
-        fhandle = fsspec.open(filepath, "rb").__enter__()
+        fhandle = fsspec.open(str(filepath), "rb").__enter__()  # can be Pathy, so add str()
 
     image = Image.open(fhandle)  # lazy loading, so it's ok to open
     size = image.size


### PR DESCRIPTION
Где возникла проблема: в трубе добавлял шаг `Inference_DetectionModel`, фотки были из S3. Под капотом создается `ImageData`, внутри происходит сначала `image_path = Pathy.fluid(image_path)`, а потом `get_image_size()`. Получается, что если путь из S3 и он оборачивается в Pathy, а потом делается `fsspec.open(filepath, "rb")` внутри `get_image_size`, то вылезет ошибка `TypeError: argument of type 'Pathy' is not iterable`, потому что видимо fsspec проверяет типа `"::" in filepath...` и падает. 

Как проще воспроизвести ошибку:
```python
from pathy import Pathy
from cv_pipeliner.utils.imagesize import get_image_size

path = Pathy.fluid("s3://bucket/img.webp")  # какой-то публичный путь, но можно даже ненастоящий
get_image_size(path)
```

Фикс - добавление обертки str(): 
`fsspec.open(str(filepath), "rb")` вместо `fsspec.open(filepath, "rb")`.